### PR TITLE
feat: add prompt generation and verification scripts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,21 @@
+# Copilot Instructions — GSD Copilot Port
+
+This repo is a fork of gsd-build/get-shit-done.
+
+## Maintain a derived compatibility layer
+Do not rewrite upstream content. Instead:
+- Generate VS Code prompt files in .github/prompts using scripts/generate-prompts.mjs
+- Verify prompt coverage using scripts/verify-prompts.mjs
+- Keep custom agent profiles in .github/agents minimal and stable
+
+## When working on sync PRs
+- Prefer fixing the generator over hand-editing many prompt files.
+- Keep diffs minimal and easy to review.
+
+## When upstream changes break the generator
+If a sync PR fails validation:
+- Invoke `@gsd-upstream-sync` agent
+- Agent will diagnose what broke and fix the generator/verifier scripts
+- Never manually edit upstream content (`commands/gsd/`, `get-shit-done/workflows/`, `agents/`)
+- See `.github/instructions/upstream-sync-guide.md` for details
+

--- a/.github/instructions/gsd-port.instructions.md
+++ b/.github/instructions/gsd-port.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: ".github/prompts/**/*.prompt.md,.github/agents/**/*.agent.md,scripts/generate-prompts.mjs,scripts/verify-prompts.mjs"
+excludeAgent: "code-review"
+---
+
+# Copilot Port Guardrails
+
+- Treat .github/prompts as GENERATED output. Prefer editing the generator.
+- Keep prompt file names stable and deterministic.
+- Keep agent profiles small; do not embed huge workflow docs inside them.

--- a/.github/instructions/upstream-sync-guide.md
+++ b/.github/instructions/upstream-sync-guide.md
@@ -1,0 +1,195 @@
+# Upstream Sync Guide
+
+This fork automatically syncs with `gsd-build/get-shit-done` using GitHub Actions and the gsd-upstream-sync agent.
+
+## How It Works
+
+### Automatic Sync (Daily)
+1. **GitHub Action triggers** (`upstream-sync.yml`): daily at 6 AM UTC (or on manual dispatch)
+2. **Detects upstream changes** by comparing with `upstream/main`
+3. **Merges upstream** using `git merge upstream/main`
+4. **Regenerates wrappers** using `scripts/generate-prompts.mjs` and `scripts/verify-prompts.mjs`
+5. **Creates PR** for human review if everything passes
+
+### If Validation Fails
+1. GitHub Action detects that generator or verifier fails
+2. **gsd-upstream-sync agent is invoked** (via Claude Code or manual invocation)
+3. Agent:
+   - Analyzes upstream changes
+   - Diagnoses what broke in the generator/verifier
+   - **Fixes the scripts** (not upstream content)
+   - Re-runs validation
+   - Commits changes
+4. Human reviews and merges PR
+
+## Key Invariant
+
+**Never rewrite upstream content.** The golden rule from `AGENTS.md`:
+
+```
+Upstream directories remain source-of-truth:
+- commands/gsd/**
+- get-shit-done/workflows/**
+- agents/**
+
+Only maintain the Copilot wrapper layer:
+- .github/prompts/**  (generated from commands/gsd/)
+- .github/agents/**   (custom Copilot profiles)
+- scripts/            (generator/verifier that maintains wrapper layer)
+```
+
+## Manual Sync (If Needed)
+
+### Option 1: Trigger GitHub Action
+```bash
+# Go to Actions > Upstream Sync > Run workflow
+```
+
+### Option 2: Manual Merge + Regenerate
+
+```bash
+# Add upstream remote (one-time setup)
+git remote add upstream https://github.com/gsd-build/get-shit-done.git
+
+# Fetch latest from upstream
+git fetch upstream main
+
+# Merge
+git merge upstream/main
+
+# Regenerate prompts
+node scripts/generate-prompts.mjs
+
+# Verify
+node scripts/verify-prompts.mjs
+
+# If either fails, invoke the sync agent via Claude Code:
+# > @gsd-upstream-sync analyze why the generator broke and fix it
+```
+
+### Option 3: Invoke Sync Agent Directly
+
+If you're in Claude Code (GitHub Copilot):
+
+```
+@gsd-upstream-sync 
+
+The upstream merge succeeded but verification failed. 
+Diagnose and fix the generator/verifier scripts.
+```
+
+Agent will:
+1. Read the failing scripts
+2. Analyze upstream changes
+3. Identify what broke
+4. Fix the generator or verifier
+5. Verify the fix works
+6. Commit and report
+
+## Common Scenarios
+
+### Scenario: New Commands Added Upstream
+- ✅ Generator automatically discovers new files in `commands/gsd/`
+- ✅ New prompts generated in `.github/prompts/`
+- ✅ Verifier confirms all commands have prompts
+- → PR created automatically
+
+### Scenario: Command Metadata Format Changed
+- ❌ Generator fails because YAML parser expects old format
+- → Sync agent invoked
+- → Agent fixes `parseFrontmatter()` in generator
+- → Scripts re-run and pass
+- → PR created
+
+### Scenario: Upstream Agent Removed/Renamed
+- ✅ Generator only processes `commands/gsd/` (not affected by upstream agents)
+- ✅ Verifier only checks prompt generation (not affected)
+- → No validation failure
+- → PR created normally
+
+### Scenario: Merge Conflict (Rare)
+- ❌ `git merge upstream/main` fails with conflicts
+- → Workflow aborts (merge reverted)
+- → Manual intervention required
+- → Resolve conflict locally, then re-run workflow
+
+**To resolve manually:**
+```bash
+git fetch upstream main
+git merge upstream/main
+# Resolve conflicts (usually in .github/prompts/ from parallel edits)
+git add .
+git commit -m "merge(upstream): resolve conflicts"
+git push
+# Trigger workflow again
+```
+
+## Monitoring
+
+### Check Sync Status
+```bash
+# Last sync
+git log --oneline | grep "merge(upstream)"
+
+# Compare with upstream
+git log --oneline HEAD..upstream/main
+
+# Check for uncommitted changes
+git status
+```
+
+### View Workflow Logs
+- Go to Actions > Upstream Sync > [latest run]
+- Look for:
+  - ✅ "No upstream changes" — already in sync
+  - ✅ "wrapper_changed=true" — PR was created
+  - ❌ "validation_failed=true" — sync agent was invoked
+  - ❌ Merge failure — manual intervention needed
+
+## Troubleshooting
+
+### Generator Fails: "No command files found"
+- **Cause:** `commands/gsd/` directory structure changed in upstream
+- **Fix:** Sync agent updates the file listing logic in generator
+
+### Verifier Fails: "Missing generated prompt files"
+- **Cause:** New commands added, but generator didn't create prompts
+- **Fix:** Sync agent debugs why generator skipped them
+
+### Verifier Fails: "Prompt naming mismatch"
+- **Cause:** Upstream changed command naming convention
+- **Fix:** Sync agent updates `normalizeName()` function
+
+### PR Has Too Many Changes
+- **Cause:** Generator output changed (formatting, path normalization, etc.)
+- **Audit:** Review `.github/prompts/` diff to ensure it's expected
+- **If unexpected:** Check what upstream changed that caused it
+
+## Maintenance Tasks
+
+### Annual Code Review
+Once a year, review the generator and verifier for:
+- [ ] Are there edge cases in YAML parsing?
+- [ ] Could path normalization fail on edge cases?
+- [ ] Does `normalizeName()` correctly pass through upstream `gsd:<cmd>` colon syntax?
+- [ ] Are error messages helpful?
+
+### Update Cron Schedule
+Edit `.github/workflows/upstream-sync.yml` if sync frequency needs to change:
+```yaml
+schedule:
+  - cron: '0 6 * * *'  # ← Change this (day of week, time, etc.)
+```
+
+Cron format: `minute hour day month day-of-week`
+- `0 6 * * *` = daily 6 AM
+- `0 6 * * 1` = every Monday 6 AM (weekly)
+- `0 0 1 * *` = monthly on 1st at midnight
+
+## Questions?
+
+- **How do I customize sync behavior?** Edit `.github/workflows/upstream-sync.yml`
+- **How do I prevent a sync?** Disable the workflow in GitHub Actions
+- **How do I sync a specific commit?** Use `git merge <commit-hash>` manually
+- **How do I revert a sync?** `git revert <sync-commit-hash>`
+

--- a/.github/prompts/gsd.add-phase.prompt.md
+++ b/.github/prompts/gsd.add-phase.prompt.md
@@ -1,0 +1,43 @@
+---
+name: gsd.add-phase
+description: "Add phase to end of current milestone in roadmap"
+argument-hint: "<description>"
+tools: ['edit', 'execute', 'read']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Bash"] -->
+
+<objective>
+Add a new integer phase to the end of the current milestone in the roadmap.
+
+Routes to the add-phase workflow which handles:
+- Phase number calculation (next sequential integer)
+- Directory creation with slug generation
+- Roadmap structure updates
+- STATE.md roadmap evolution tracking
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/add-phase.md
+</execution_context>
+
+<context>
+Arguments: $ARGUMENTS (phase description)
+
+Roadmap and state are resolved in-workflow via `init phase-op` and targeted tool calls.
+</context>
+
+<process>
+**Follow the add-phase workflow** from `@./.claude/get-shit-done/workflows/add-phase.md`.
+
+The workflow handles all logic including:
+1. Argument parsing and validation
+2. Roadmap existence checking
+3. Current milestone identification
+4. Next phase number calculation (ignoring decimals)
+5. Slug generation from description
+6. Phase directory creation
+7. Roadmap entry insertion
+8. STATE.md updates
+</process>

--- a/.github/prompts/gsd.add-tests.prompt.md
+++ b/.github/prompts/gsd.add-tests.prompt.md
@@ -1,0 +1,51 @@
+---
+name: gsd.add-tests
+description: "Generate tests for a completed phase based on UAT criteria and implementation"
+argument-hint: "<phase> [additional instructions]"
+tools: ['agent', 'edit', 'execute', 'read', 'search', 'vscode/askQuestions']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Edit","Bash","Glob","Grep","Task","AskUserQuestion"] -->
+
+## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an `AskUserQuestion` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named `AskUserQuestion`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+
+<objective>
+Generate unit and E2E tests for a completed phase, using its SUMMARY.md, CONTEXT.md, and VERIFICATION.md as specifications.
+
+Analyzes implementation files, classifies them into TDD (unit), E2E (browser), or Skip categories, presents a test plan for user approval, then generates tests following RED-GREEN conventions.
+
+Output: Test files committed with message `test(phase-{N}): add unit and E2E tests from add-tests command`
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/add-tests.md
+</execution_context>
+
+<context>
+Phase: $ARGUMENTS
+- Read file at: .planning/STATE.md
+- Read file at: .planning/ROADMAP.md
+</context>
+
+<process>
+Execute the add-tests workflow from @./.claude/get-shit-done/workflows/add-tests.md end-to-end.
+Preserve all workflow gates (classification approval, test plan approval, RED-GREEN verification, gap reporting).
+</process>

--- a/.github/prompts/gsd.add-todo.prompt.md
+++ b/.github/prompts/gsd.add-todo.prompt.md
@@ -1,0 +1,65 @@
+---
+name: gsd.add-todo
+description: "Capture idea or task as todo from current conversation context"
+argument-hint: "[optional description]"
+tools: ['edit', 'execute', 'read', 'vscode/askQuestions']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Bash","AskUserQuestion"] -->
+
+## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an `AskUserQuestion` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named `AskUserQuestion`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+
+<objective>
+Capture an idea, task, or issue that surfaces during a GSD session as a structured todo for later work.
+
+Routes to the add-todo workflow which handles:
+- Directory structure creation
+- Content extraction from arguments or conversation
+- Area inference from file paths
+- Duplicate detection and resolution
+- Todo file creation with frontmatter
+- STATE.md updates
+- Git commits
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/add-todo.md
+</execution_context>
+
+<context>
+Arguments: $ARGUMENTS (optional todo description)
+
+State is resolved in-workflow via `init todos` and targeted reads.
+</context>
+
+<process>
+**Follow the add-todo workflow** from `@./.claude/get-shit-done/workflows/add-todo.md`.
+
+The workflow handles all logic including:
+1. Directory ensuring
+2. Existing area checking
+3. Content extraction (arguments or conversation)
+4. Area inference
+5. Duplicate checking
+6. File creation with slug generation
+7. STATE.md updates
+8. Git commits
+</process>

--- a/.github/prompts/gsd.audit-milestone.prompt.md
+++ b/.github/prompts/gsd.audit-milestone.prompt.md
@@ -1,0 +1,34 @@
+---
+name: gsd.audit-milestone
+description: "Audit milestone completion against original intent before archiving"
+argument-hint: "[version]"
+tools: ['agent', 'edit', 'execute', 'read', 'search']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Glob","Grep","Bash","Task","Write"] -->
+
+<objective>
+Verify milestone achieved its definition of done. Check requirements coverage, cross-phase integration, and end-to-end flows.
+
+**This command IS the orchestrator.** Reads existing VERIFICATION.md files (phases already verified during execute-phase), aggregates tech debt and deferred gaps, then spawns integration checker for cross-phase wiring.
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/audit-milestone.md
+</execution_context>
+
+<context>
+Version: $ARGUMENTS (optional — defaults to current milestone)
+
+Core planning files are resolved in-workflow (`init milestone-op`) and loaded only as needed.
+
+**Completed Work:**
+Glob: .planning/phases/*/*-SUMMARY.md
+Glob: .planning/phases/*/*-VERIFICATION.md
+</context>
+
+<process>
+Execute the audit-milestone workflow from @./.claude/get-shit-done/workflows/audit-milestone.md end-to-end.
+Preserve all workflow gates (scope determination, verification reading, integration check, requirements coverage, routing).
+</process>

--- a/.github/prompts/gsd.check-todos.prompt.md
+++ b/.github/prompts/gsd.check-todos.prompt.md
@@ -1,0 +1,63 @@
+---
+name: gsd.check-todos
+description: "List pending todos and select one to work on"
+argument-hint: "[area filter]"
+tools: ['edit', 'execute', 'read', 'vscode/askQuestions']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Bash","AskUserQuestion"] -->
+
+## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an `AskUserQuestion` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named `AskUserQuestion`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+
+<objective>
+List all pending todos, allow selection, load full context for the selected todo, and route to appropriate action.
+
+Routes to the check-todos workflow which handles:
+- Todo counting and listing with area filtering
+- Interactive selection with full context loading
+- Roadmap correlation checking
+- Action routing (work now, add to phase, brainstorm, create phase)
+- STATE.md updates and git commits
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/check-todos.md
+</execution_context>
+
+<context>
+Arguments: $ARGUMENTS (optional area filter)
+
+Todo state and roadmap correlation are loaded in-workflow using `init todos` and targeted reads.
+</context>
+
+<process>
+**Follow the check-todos workflow** from `@./.claude/get-shit-done/workflows/check-todos.md`.
+
+The workflow handles all logic including:
+1. Todo existence checking
+2. Area filtering
+3. Interactive listing and selection
+4. Full context loading with file summaries
+5. Roadmap correlation checking
+6. Action offering and execution
+7. STATE.md updates
+8. Git commits
+</process>

--- a/.github/prompts/gsd.cleanup.prompt.md
+++ b/.github/prompts/gsd.cleanup.prompt.md
@@ -1,0 +1,22 @@
+---
+name: gsd.cleanup
+description: "Archive accumulated phase directories from completed milestones"
+agent: agent
+---
+
+<!-- upstream-tools: null (field absent in upstream command) -->
+
+<objective>
+Archive phase directories from completed milestones into `.planning/milestones/v{X.Y}-phases/`.
+
+Use when `.planning/phases/` has accumulated directories from past milestones.
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/cleanup.md
+</execution_context>
+
+<process>
+Follow the cleanup workflow at @./.claude/get-shit-done/workflows/cleanup.md.
+Identify completed milestones, show a dry-run summary, and archive on confirmation.
+</process>

--- a/.github/prompts/gsd.complete-milestone.prompt.md
+++ b/.github/prompts/gsd.complete-milestone.prompt.md
@@ -1,0 +1,135 @@
+---
+name: gsd.complete-milestone
+description: "Archive completed milestone and prepare for next version"
+argument-hint: "<version>"
+tools: ['edit', 'execute', 'read']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Bash"] -->
+
+<objective>
+Mark milestone {{version}} complete, archive to milestones/, and update ROADMAP.md and REQUIREMENTS.md.
+
+Purpose: Create historical record of shipped version, archive milestone artifacts (roadmap + requirements), and prepare for next milestone.
+Output: Milestone archived (roadmap + requirements), PROJECT.md evolved, git tagged.
+</objective>
+
+<execution_context>
+**Load these files NOW (before proceeding):**
+
+- @./.claude/get-shit-done/workflows/complete-milestone.md (main workflow)
+- @./.claude/get-shit-done/templates/milestone-archive.md (archive template)
+  </execution_context>
+
+<context>
+**Project files:**
+- `.planning/ROADMAP.md`
+- `.planning/REQUIREMENTS.md`
+- `.planning/STATE.md`
+- `.planning/PROJECT.md`
+
+**User input:**
+
+- Version: {{version}} (e.g., "1.0", "1.1", "2.0")
+  </context>
+
+<process>
+
+**Follow complete-milestone.md workflow:**
+
+0. **Check for audit:**
+
+   - Look for `.planning/v{{version}}-MILESTONE-AUDIT.md`
+   - If missing or stale: recommend `/gsd:audit-milestone` first
+   - If audit status is `gaps_found`: recommend `/gsd:plan-milestone-gaps` first
+   - If audit status is `passed`: proceed to step 1
+
+   ```markdown
+   ## Pre-flight Check
+
+   {If no v{{version}}-MILESTONE-AUDIT.md:}
+   ⚠ No milestone audit found. Run `/gsd:audit-milestone` first to verify
+   requirements coverage, cross-phase integration, and E2E flows.
+
+   {If audit has gaps:}
+   ⚠ Milestone audit found gaps. Run `/gsd:plan-milestone-gaps` to create
+   phases that close the gaps, or proceed anyway to accept as tech debt.
+
+   {If audit passed:}
+   ✓ Milestone audit passed. Proceeding with completion.
+   ```
+
+1. **Verify readiness:**
+
+   - Check all phases in milestone have completed plans (SUMMARY.md exists)
+   - Present milestone scope and stats
+   - Wait for confirmation
+
+2. **Gather stats:**
+
+   - Count phases, plans, tasks
+   - Calculate git range, file changes, LOC
+   - Extract timeline from git log
+   - Present summary, confirm
+
+3. **Extract accomplishments:**
+
+   - Read all phase SUMMARY.md files in milestone range
+   - Extract 4-6 key accomplishments
+   - Present for approval
+
+4. **Archive milestone:**
+
+   - Create `.planning/milestones/v{{version}}-ROADMAP.md`
+   - Extract full phase details from ROADMAP.md
+   - Fill milestone-archive.md template
+   - Update ROADMAP.md to one-line summary with link
+
+5. **Archive requirements:**
+
+   - Create `.planning/milestones/v{{version}}-REQUIREMENTS.md`
+   - Mark all v1 requirements as complete (checkboxes checked)
+   - Note requirement outcomes (validated, adjusted, dropped)
+   - Delete `.planning/REQUIREMENTS.md` (fresh one created for next milestone)
+
+6. **Update PROJECT.md:**
+
+   - Add "Current State" section with shipped version
+   - Add "Next Milestone Goals" section
+   - Archive previous content in `<details>` (if v1.1+)
+
+7. **Commit and tag:**
+
+   - Stage: MILESTONES.md, PROJECT.md, ROADMAP.md, STATE.md, archive files
+   - Commit: `chore: archive v{{version}} milestone`
+   - Tag: `git tag -a v{{version}} -m "[milestone summary]"`
+   - Ask about pushing tag
+
+8. **Offer next steps:**
+   - `/gsd:new-milestone` — start next milestone (questioning → research → requirements → roadmap)
+
+</process>
+
+<success_criteria>
+
+- Milestone archived to `.planning/milestones/v{{version}}-ROADMAP.md`
+- Requirements archived to `.planning/milestones/v{{version}}-REQUIREMENTS.md`
+- `.planning/REQUIREMENTS.md` deleted (fresh for next milestone)
+- ROADMAP.md collapsed to one-line entry
+- PROJECT.md updated with current state
+- Git tag v{{version}} created
+- Commit successful
+- User knows next steps (including need for fresh requirements)
+  </success_criteria>
+
+<critical_rules>
+
+- **Load workflow first:** Read complete-milestone.md before executing
+- **Verify completion:** All phases must have SUMMARY.md files
+- **User confirmation:** Wait for approval at verification gates
+- **Archive before deleting:** Always create archive files before updating/deleting originals
+- **One-line summary:** Collapsed milestone in ROADMAP.md should be single line with link
+- **Context efficiency:** Archive keeps ROADMAP.md and REQUIREMENTS.md constant size per milestone
+- **Fresh requirements:** Next milestone starts with `/gsd:new-milestone` which includes requirements definition
+  </critical_rules>

--- a/.github/prompts/gsd.debug.prompt.md
+++ b/.github/prompts/gsd.debug.prompt.md
@@ -1,0 +1,185 @@
+---
+name: gsd.debug
+description: "Systematic debugging with persistent state across context resets"
+argument-hint: "[issue description]"
+tools: ['agent', 'execute', 'read', 'vscode/askQuestions']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Bash","Task","AskUserQuestion"] -->
+
+## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an `AskUserQuestion` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named `AskUserQuestion`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+
+<objective>
+Debug issues using scientific method with subagent isolation.
+
+**Orchestrator role:** Gather symptoms, spawn gsd-debugger agent, handle checkpoints, spawn continuations.
+
+**Why subagent:** Investigation burns context fast (reading files, forming hypotheses, testing). Fresh 200k context per investigation. Main context stays lean for user interaction.
+</objective>
+
+<context>
+User's issue: $ARGUMENTS
+
+Check for active sessions:
+```bash
+ls .planning/debug/*.md 2>/dev/null | grep -v resolved | head -5
+```
+</context>
+
+<process>
+
+## 0. Initialize Context
+
+```bash
+INIT=$(node ./.claude/get-shit-done/bin/gsd-tools.cjs state load)
+```
+
+Extract `commit_docs` from init JSON. Resolve debugger model:
+```bash
+DEBUGGER_MODEL=$(node ./.claude/get-shit-done/bin/gsd-tools.cjs resolve-model gsd-debugger --raw)
+```
+
+## 1. Check Active Sessions
+
+If active sessions exist AND no $ARGUMENTS:
+- List sessions with status, hypothesis, next action
+- User picks number to resume OR describes new issue
+
+If $ARGUMENTS provided OR user describes new issue:
+- Continue to symptom gathering
+
+## 2. Gather Symptoms (if new issue)
+
+Use AskUserQuestion for each:
+
+1. **Expected behavior** - What should happen?
+2. **Actual behavior** - What happens instead?
+3. **Error messages** - Any errors? (paste or describe)
+4. **Timeline** - When did this start? Ever worked?
+5. **Reproduction** - How do you trigger it?
+
+After all gathered, confirm ready to investigate.
+
+## 3. Spawn gsd-debugger Agent
+
+Fill prompt and spawn:
+
+```markdown
+<objective>
+Investigate issue: {slug}
+
+**Summary:** {trigger}
+</objective>
+
+<symptoms>
+expected: {expected}
+actual: {actual}
+errors: {errors}
+reproduction: {reproduction}
+timeline: {timeline}
+</symptoms>
+
+<mode>
+symptoms_prefilled: true
+goal: find_and_fix
+</mode>
+
+<debug_file>
+Create: .planning/debug/{slug}.md
+</debug_file>
+```
+
+```
+Task(
+  prompt=filled_prompt,
+  subagent_type="gsd-debugger",
+  model="{debugger_model}",
+  description="Debug {slug}"
+)
+```
+
+## 4. Handle Agent Return
+
+**If `## ROOT CAUSE FOUND`:**
+- Display root cause and evidence summary
+- Offer options:
+  - "Fix now" - spawn fix subagent
+  - "Plan fix" - suggest /gsd:plan-phase --gaps
+  - "Manual fix" - done
+
+**If `## CHECKPOINT REACHED`:**
+- Present checkpoint details to user
+- Get user response
+- If checkpoint type is `human-verify`:
+  - If user confirms fixed: continue so agent can finalize/resolve/archive
+  - If user reports issues: continue so agent returns to investigation/fixing
+- Spawn continuation agent (see step 5)
+
+**If `## INVESTIGATION INCONCLUSIVE`:**
+- Show what was checked and eliminated
+- Offer options:
+  - "Continue investigating" - spawn new agent with additional context
+  - "Manual investigation" - done
+  - "Add more context" - gather more symptoms, spawn again
+
+## 5. Spawn Continuation Agent (After Checkpoint)
+
+When user responds to checkpoint, spawn fresh agent:
+
+```markdown
+<objective>
+Continue debugging {slug}. Evidence is in the debug file.
+</objective>
+
+<prior_state>
+<files_to_read>
+- .planning/debug/{slug}.md (Debug session state)
+</files_to_read>
+</prior_state>
+
+<checkpoint_response>
+**Type:** {checkpoint_type}
+**Response:** {user_response}
+</checkpoint_response>
+
+<mode>
+goal: find_and_fix
+</mode>
+```
+
+```
+Task(
+  prompt=continuation_prompt,
+  subagent_type="gsd-debugger",
+  model="{debugger_model}",
+  description="Continue debug {slug}"
+)
+```
+
+</process>
+
+<success_criteria>
+- [ ] Active sessions checked
+- [ ] Symptoms gathered (if new)
+- [ ] gsd-debugger spawned with context
+- [ ] Checkpoints handled correctly
+- [ ] Root cause confirmed before fixing
+</success_criteria>

--- a/.github/prompts/gsd.discuss-phase.prompt.md
+++ b/.github/prompts/gsd.discuss-phase.prompt.md
@@ -1,0 +1,98 @@
+---
+name: gsd.discuss-phase
+description: "Gather phase context through adaptive questioning before planning"
+argument-hint: "<phase> [--auto]"
+tools: ['agent', 'edit', 'execute', 'read', 'search', 'vscode/askQuestions']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Bash","Glob","Grep","AskUserQuestion","Task"] -->
+
+## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an `AskUserQuestion` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named `AskUserQuestion`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+
+<objective>
+Extract implementation decisions that downstream agents need — researcher and planner will use CONTEXT.md to know what to investigate and what choices are locked.
+
+**How it works:**
+1. Analyze the phase to identify gray areas (UI, UX, behavior, etc.)
+2. Present gray areas — user selects which to discuss
+3. Deep-dive each selected area until satisfied
+4. Create CONTEXT.md with decisions that guide research and planning
+
+**Output:** `{phase_num}-CONTEXT.md` — decisions clear enough that downstream agents can act without asking the user again
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/discuss-phase.md
+- Read file at: ./.claude/get-shit-done/templates/context.md
+</execution_context>
+
+<context>
+Phase number: $ARGUMENTS (required)
+
+Context files are resolved in-workflow using `init phase-op` and roadmap/state tool calls.
+</context>
+
+<process>
+1. Validate phase number (error if missing or not in roadmap)
+2. Check if CONTEXT.md exists (offer update/view/skip if yes)
+3. **Analyze phase** — Identify domain and generate phase-specific gray areas
+4. **Present gray areas** — Multi-select: which to discuss? (NO skip option)
+5. **Deep-dive each area** — 4 questions per area, then offer more/next
+6. **Write CONTEXT.md** — Sections match areas discussed
+7. Offer next steps (research or plan)
+
+**CRITICAL: Scope guardrail**
+- Phase boundary from ROADMAP.md is FIXED
+- Discussion clarifies HOW to implement, not WHETHER to add more
+- If user suggests new capabilities: "That's its own phase. I'll note it for later."
+- Capture deferred ideas — don't lose them, don't act on them
+
+**Domain-aware gray areas:**
+Gray areas depend on what's being built. Analyze the phase goal:
+- Something users SEE → layout, density, interactions, states
+- Something users CALL → responses, errors, auth, versioning
+- Something users RUN → output format, flags, modes, error handling
+- Something users READ → structure, tone, depth, flow
+- Something being ORGANIZED → criteria, grouping, naming, exceptions
+
+Generate 3-4 **phase-specific** gray areas, not generic categories.
+
+**Probing depth:**
+- Ask 4 questions per area before checking
+- "More questions about [area], or move to next?"
+- If more → ask 4 more, check again
+- After all areas → "Ready to create context?"
+
+**Do NOT ask about (Claude handles these):**
+- Technical implementation
+- Architecture choices
+- Performance concerns
+- Scope expansion
+</process>
+
+<success_criteria>
+- Gray areas identified through intelligent analysis
+- User chose which areas to discuss
+- Each selected area explored until satisfied
+- Scope creep redirected to deferred ideas
+- CONTEXT.md captures decisions, not vague vision
+- User knows next steps
+</success_criteria>

--- a/.github/prompts/gsd.execute-phase.prompt.md
+++ b/.github/prompts/gsd.execute-phase.prompt.md
@@ -1,0 +1,55 @@
+---
+name: gsd.execute-phase
+description: "Execute all plans in a phase with wave-based parallelization"
+argument-hint: "<phase-number> [--gaps-only]"
+tools: ['agent', 'edit', 'execute', 'read', 'search', 'todo', 'vscode/askQuestions']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Edit","Glob","Grep","Bash","Task","TodoWrite","AskUserQuestion"] -->
+
+## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an `AskUserQuestion` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named `AskUserQuestion`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+
+<objective>
+Execute all plans in a phase using wave-based parallel execution.
+
+Orchestrator stays lean: discover plans, analyze dependencies, group into waves, spawn subagents, collect results. Each subagent loads the full execute-plan context and handles its own plan.
+
+Context budget: ~15% orchestrator, 100% fresh per subagent.
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/execute-phase.md
+- Read file at: ./.claude/get-shit-done/references/ui-brand.md
+</execution_context>
+
+<context>
+Phase: $ARGUMENTS
+
+**Flags:**
+- `--gaps-only` — Execute only gap closure plans (plans with `gap_closure: true` in frontmatter). Use after verify-work creates fix plans.
+
+Context files are resolved inside the workflow via `gsd-tools init execute-phase` and per-subagent `<files_to_read>` blocks.
+</context>
+
+<process>
+Execute the execute-phase workflow from @./.claude/get-shit-done/workflows/execute-phase.md end-to-end.
+Preserve all workflow gates (wave execution, checkpoint handling, verification, state updates, routing).
+</process>

--- a/.github/prompts/gsd.health.prompt.md
+++ b/.github/prompts/gsd.health.prompt.md
@@ -1,0 +1,41 @@
+---
+name: gsd.health
+description: "Diagnose planning directory health and optionally repair issues"
+argument-hint: "[--repair]"
+tools: ['edit', 'execute', 'read', 'vscode/askQuestions']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Bash","Write","AskUserQuestion"] -->
+
+## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an `AskUserQuestion` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named `AskUserQuestion`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+
+<objective>
+Validate `.planning/` directory integrity and report actionable issues. Checks for missing files, invalid configurations, inconsistent state, and orphaned plans.
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/health.md
+</execution_context>
+
+<process>
+Execute the health workflow from @./.claude/get-shit-done/workflows/health.md end-to-end.
+Parse --repair flag from arguments and pass to workflow.
+</process>

--- a/.github/prompts/gsd.help.prompt.md
+++ b/.github/prompts/gsd.help.prompt.md
@@ -1,0 +1,26 @@
+---
+name: gsd.help
+description: "Show available GSD commands and usage guide"
+agent: agent
+---
+
+<!-- upstream-tools: null (field absent in upstream command) -->
+
+<objective>
+Display the complete GSD command reference.
+
+Output ONLY the reference content below. Do NOT add:
+- Project-specific analysis
+- Git status or file context
+- Next-step suggestions
+- Any commentary beyond the reference
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/help.md
+</execution_context>
+
+<process>
+Output the complete GSD command reference from @./.claude/get-shit-done/workflows/help.md.
+Display the reference content directly — no additions or modifications.
+</process>

--- a/.github/prompts/gsd.insert-phase.prompt.md
+++ b/.github/prompts/gsd.insert-phase.prompt.md
@@ -1,0 +1,32 @@
+---
+name: gsd.insert-phase
+description: "Insert urgent work as decimal phase (e.g., 72.1) between existing phases"
+argument-hint: "<after> <description>"
+tools: ['edit', 'execute', 'read']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Bash"] -->
+
+<objective>
+Insert a decimal phase for urgent work discovered mid-milestone that must be completed between existing integer phases.
+
+Uses decimal numbering (72.1, 72.2, etc.) to preserve the logical sequence of planned phases while accommodating urgent insertions.
+
+Purpose: Handle urgent work discovered during execution without renumbering entire roadmap.
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/insert-phase.md
+</execution_context>
+
+<context>
+Arguments: $ARGUMENTS (format: <after-phase-number> <description>)
+
+Roadmap and state are resolved in-workflow via `init phase-op` and targeted tool calls.
+</context>
+
+<process>
+Execute the insert-phase workflow from @./.claude/get-shit-done/workflows/insert-phase.md end-to-end.
+Preserve all validation gates (argument parsing, phase verification, decimal calculation, roadmap updates).
+</process>

--- a/.github/prompts/gsd.join-discord.prompt.md
+++ b/.github/prompts/gsd.join-discord.prompt.md
@@ -1,0 +1,21 @@
+---
+name: gsd.join-discord
+description: "Join the GSD Discord community"
+agent: agent
+---
+
+<!-- upstream-tools: null (field absent in upstream command) -->
+
+<objective>
+Display the Discord invite link for the GSD community server.
+</objective>
+
+<output>
+# Join the GSD Discord
+
+Connect with other GSD users, get help, share what you're building, and stay updated.
+
+**Invite link:** https://discord.gg/5JJgD5svVS
+
+Click the link or paste it into your browser to join.
+</output>

--- a/.github/prompts/gsd.list-phase-assumptions.prompt.md
+++ b/.github/prompts/gsd.list-phase-assumptions.prompt.md
@@ -1,0 +1,45 @@
+---
+name: gsd.list-phase-assumptions
+description: "Surface Claude's assumptions about a phase approach before planning"
+argument-hint: "[phase]"
+tools: ['execute', 'read', 'search']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Bash","Grep","Glob"] -->
+
+<objective>
+Analyze a phase and present Claude's assumptions about technical approach, implementation order, scope boundaries, risk areas, and dependencies.
+
+Purpose: Help users see what Claude thinks BEFORE planning begins - enabling course correction early when assumptions are wrong.
+Output: Conversational output only (no file creation) - ends with "What do you think?" prompt
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/list-phase-assumptions.md
+</execution_context>
+
+<context>
+Phase number: $ARGUMENTS (required)
+
+Project state and roadmap are loaded in-workflow using targeted reads.
+</context>
+
+<process>
+1. Validate phase number argument (error if missing or invalid)
+2. Check if phase exists in roadmap
+3. Follow list-phase-assumptions.md workflow:
+   - Analyze roadmap description
+   - Surface assumptions about: technical approach, implementation order, scope, risks, dependencies
+   - Present assumptions clearly
+   - Prompt "What do you think?"
+4. Gather feedback and offer next steps
+</process>
+
+<success_criteria>
+
+- Phase validated against roadmap
+- Assumptions surfaced across five areas
+- User prompted for feedback
+- User knows next steps (discuss context, plan phase, or correct assumptions)
+  </success_criteria>

--- a/.github/prompts/gsd.map-codebase.prompt.md
+++ b/.github/prompts/gsd.map-codebase.prompt.md
@@ -1,0 +1,68 @@
+---
+name: gsd.map-codebase
+description: "Analyze codebase with parallel mapper agents to produce .planning/codebase/ documents"
+argument-hint: "[optional: specific area to map, e.g., 'api' or 'auth']"
+tools: ['agent', 'edit', 'execute', 'read', 'search']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Bash","Glob","Grep","Write","Task"] -->
+
+<objective>
+Analyze existing codebase using parallel gsd-codebase-mapper agents to produce structured codebase documents.
+
+Each mapper agent explores a focus area and **writes documents directly** to `.planning/codebase/`. The orchestrator only receives confirmations, keeping context usage minimal.
+
+Output: .planning/codebase/ folder with 7 structured documents about the codebase state.
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/map-codebase.md
+</execution_context>
+
+<context>
+Focus area: $ARGUMENTS (optional - if provided, tells agents to focus on specific subsystem)
+
+**Load project state if exists:**
+Check for .planning/STATE.md - loads context if project already initialized
+
+**This command can run:**
+- Before /gsd:new-project (brownfield codebases) - creates codebase map first
+- After /gsd:new-project (greenfield codebases) - updates codebase map as code evolves
+- Anytime to refresh codebase understanding
+</context>
+
+<when_to_use>
+**Use map-codebase for:**
+- Brownfield projects before initialization (understand existing code first)
+- Refreshing codebase map after significant changes
+- Onboarding to an unfamiliar codebase
+- Before major refactoring (understand current state)
+- When STATE.md references outdated codebase info
+
+**Skip map-codebase for:**
+- Greenfield projects with no code yet (nothing to map)
+- Trivial codebases (<5 files)
+</when_to_use>
+
+<process>
+1. Check if .planning/codebase/ already exists (offer to refresh or skip)
+2. Create .planning/codebase/ directory structure
+3. Spawn 4 parallel gsd-codebase-mapper agents:
+   - Agent 1: tech focus → writes STACK.md, INTEGRATIONS.md
+   - Agent 2: arch focus → writes ARCHITECTURE.md, STRUCTURE.md
+   - Agent 3: quality focus → writes CONVENTIONS.md, TESTING.md
+   - Agent 4: concerns focus → writes CONCERNS.md
+4. Wait for agents to complete, collect confirmations (NOT document contents)
+5. Verify all 7 documents exist with line counts
+6. Commit codebase map
+7. Offer next steps (typically: /gsd:new-project or /gsd:plan-phase)
+</process>
+
+<success_criteria>
+- [ ] .planning/codebase/ directory created
+- [ ] All 7 codebase documents written by mapper agents
+- [ ] Documents follow template structure
+- [ ] Parallel agents completed without errors
+- [ ] User knows next steps
+</success_criteria>

--- a/.github/prompts/gsd.new-milestone.prompt.md
+++ b/.github/prompts/gsd.new-milestone.prompt.md
@@ -1,0 +1,62 @@
+---
+name: gsd.new-milestone
+description: "Start a new milestone cycle — update PROJECT.md and route to requirements"
+argument-hint: "[milestone name, e.g., 'v1.1 Notifications']"
+tools: ['agent', 'edit', 'execute', 'read', 'vscode/askQuestions']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Bash","Task","AskUserQuestion"] -->
+
+## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an `AskUserQuestion` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named `AskUserQuestion`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+
+<objective>
+Start a new milestone: questioning → research (optional) → requirements → roadmap.
+
+Brownfield equivalent of new-project. Project exists, PROJECT.md has history. Gathers "what's next", updates PROJECT.md, then runs requirements → roadmap cycle.
+
+**Creates/Updates:**
+- `.planning/PROJECT.md` — updated with new milestone goals
+- `.planning/research/` — domain research (optional, NEW features only)
+- `.planning/REQUIREMENTS.md` — scoped requirements for this milestone
+- `.planning/ROADMAP.md` — phase structure (continues numbering)
+- `.planning/STATE.md` — reset for new milestone
+
+**After:** `/gsd:plan-phase [N]` to start execution.
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/new-milestone.md
+- Read file at: ./.claude/get-shit-done/references/questioning.md
+- Read file at: ./.claude/get-shit-done/references/ui-brand.md
+- Read file at: ./.claude/get-shit-done/templates/project.md
+- Read file at: ./.claude/get-shit-done/templates/requirements.md
+</execution_context>
+
+<context>
+Milestone name: $ARGUMENTS (optional - will prompt if not provided)
+
+Project and milestone context files are resolved inside the workflow (`init new-milestone`) and delegated via `<files_to_read>` blocks where subagents are used.
+</context>
+
+<process>
+Execute the new-milestone workflow from @./.claude/get-shit-done/workflows/new-milestone.md end-to-end.
+Preserve all workflow gates (validation, questioning, research, requirements, roadmap approval, commits).
+</process>

--- a/.github/prompts/gsd.new-project.prompt.md
+++ b/.github/prompts/gsd.new-project.prompt.md
@@ -1,0 +1,60 @@
+---
+name: gsd.new-project
+description: "Initialize a new project with deep context gathering and PROJECT.md"
+argument-hint: "[--auto]"
+tools: ['agent', 'edit', 'execute', 'read', 'vscode/askQuestions']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Bash","Write","Task","AskUserQuestion"] -->
+
+## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an `AskUserQuestion` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named `AskUserQuestion`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+
+<context>
+**Flags:**
+- `--auto` — Automatic mode. After config questions, runs research → requirements → roadmap without further interaction. Expects idea document via @ reference.
+</context>
+
+<objective>
+Initialize a new project through unified flow: questioning → research (optional) → requirements → roadmap.
+
+**Creates:**
+- `.planning/PROJECT.md` — project context
+- `.planning/config.json` — workflow preferences
+- `.planning/research/` — domain research (optional)
+- `.planning/REQUIREMENTS.md` — scoped requirements
+- `.planning/ROADMAP.md` — phase structure
+- `.planning/STATE.md` — project memory
+
+**After this command:** Run `/gsd:plan-phase 1` to start execution.
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/new-project.md
+- Read file at: ./.claude/get-shit-done/references/questioning.md
+- Read file at: ./.claude/get-shit-done/references/ui-brand.md
+- Read file at: ./.claude/get-shit-done/templates/project.md
+- Read file at: ./.claude/get-shit-done/templates/requirements.md
+</execution_context>
+
+<process>
+Execute the new-project workflow from @./.claude/get-shit-done/workflows/new-project.md end-to-end.
+Preserve all workflow gates (validation, approvals, commits, routing).
+</process>

--- a/.github/prompts/gsd.pause-work.prompt.md
+++ b/.github/prompts/gsd.pause-work.prompt.md
@@ -1,0 +1,38 @@
+---
+name: gsd.pause-work
+description: "Create context handoff when pausing work mid-phase"
+tools: ['edit', 'execute', 'read']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Bash"] -->
+
+<objective>
+Create `.continue-here.md` handoff file to preserve complete work state across sessions.
+
+Routes to the pause-work workflow which handles:
+- Current phase detection from recent files
+- Complete state gathering (position, completed work, remaining work, decisions, blockers)
+- Handoff file creation with all context sections
+- Git commit as WIP
+- Resume instructions
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/pause-work.md
+</execution_context>
+
+<context>
+State and phase progress are gathered in-workflow with targeted reads.
+</context>
+
+<process>
+**Follow the pause-work workflow** from `@./.claude/get-shit-done/workflows/pause-work.md`.
+
+The workflow handles all logic including:
+1. Phase directory detection
+2. State gathering with user clarifications
+3. Handoff file writing with timestamp
+4. Git commit
+5. Confirmation with resume instructions
+</process>

--- a/.github/prompts/gsd.plan-milestone-gaps.prompt.md
+++ b/.github/prompts/gsd.plan-milestone-gaps.prompt.md
@@ -1,0 +1,51 @@
+---
+name: gsd.plan-milestone-gaps
+description: "Create phases to close all gaps identified by milestone audit"
+tools: ['edit', 'execute', 'read', 'search', 'vscode/askQuestions']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Bash","Glob","Grep","AskUserQuestion"] -->
+
+## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an `AskUserQuestion` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named `AskUserQuestion`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+
+<objective>
+Create all phases necessary to close gaps identified by `/gsd:audit-milestone`.
+
+Reads MILESTONE-AUDIT.md, groups gaps into logical phases, creates phase entries in ROADMAP.md, and offers to plan each phase.
+
+One command creates all fix phases — no manual `/gsd:add-phase` per gap.
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/plan-milestone-gaps.md
+</execution_context>
+
+<context>
+**Audit results:**
+Glob: .planning/v*-MILESTONE-AUDIT.md (use most recent)
+
+Original intent and current planning state are loaded on demand inside the workflow.
+</context>
+
+<process>
+Execute the plan-milestone-gaps workflow from @./.claude/get-shit-done/workflows/plan-milestone-gaps.md end-to-end.
+Preserve all workflow gates (audit loading, prioritization, phase grouping, user confirmation, roadmap updates).
+</process>

--- a/.github/prompts/gsd.plan-phase.prompt.md
+++ b/.github/prompts/gsd.plan-phase.prompt.md
@@ -1,0 +1,40 @@
+---
+name: gsd.plan-phase
+description: "Create detailed phase plan (PLAN.md) with verification loop"
+argument-hint: "[phase] [--auto] [--research] [--skip-research] [--gaps] [--skip-verify] [--prd <file>]"
+tools: ['agent', 'edit', 'execute', 'mcp__context7__*', 'read', 'search', 'web']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Bash","Glob","Grep","Task","WebFetch","mcp__context7__*"] -->
+
+<objective>
+Create executable phase prompts (PLAN.md files) for a roadmap phase with integrated research and verification.
+
+**Default flow:** Research (if needed) → Plan → Verify → Done
+
+**Orchestrator role:** Parse arguments, validate phase, research domain (unless skipped), spawn gsd-planner, verify with gsd-plan-checker, iterate until pass or max iterations, present results.
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/plan-phase.md
+- Read file at: ./.claude/get-shit-done/references/ui-brand.md
+</execution_context>
+
+<context>
+Phase number: $ARGUMENTS (optional — auto-detects next unplanned phase if omitted)
+
+**Flags:**
+- `--research` — Force re-research even if RESEARCH.md exists
+- `--skip-research` — Skip research, go straight to planning
+- `--gaps` — Gap closure mode (reads VERIFICATION.md, skips research)
+- `--skip-verify` — Skip verification loop
+- `--prd <file>` — Use a PRD/acceptance criteria file instead of discuss-phase. Parses requirements into CONTEXT.md automatically. Skips discuss-phase entirely.
+
+Normalize phase input in step 2 before any directory lookups.
+</context>
+
+<process>
+Execute the plan-phase workflow from @./.claude/get-shit-done/workflows/plan-phase.md end-to-end.
+Preserve all workflow gates (validation, research, planning, verification loop, routing).
+</process>

--- a/.github/prompts/gsd.progress.prompt.md
+++ b/.github/prompts/gsd.progress.prompt.md
@@ -1,0 +1,24 @@
+---
+name: gsd.progress
+description: "Check project progress, show context, and route to next action (execute or plan)"
+tools: ['execute', 'read', 'search']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Bash","Grep","Glob","SlashCommand"] -->
+<!-- omitted-tools: ["slashcommand"] — no Copilot equivalent found -->
+
+<objective>
+Check project progress, summarize recent work and what's ahead, then intelligently route to the next action - either executing an existing plan or creating the next one.
+
+Provides situational awareness before continuing work.
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/progress.md
+</execution_context>
+
+<process>
+Execute the progress workflow from @./.claude/get-shit-done/workflows/progress.md end-to-end.
+Preserve all routing logic (Routes A through F) and edge case handling.
+</process>

--- a/.github/prompts/gsd.quick.prompt.md
+++ b/.github/prompts/gsd.quick.prompt.md
@@ -1,0 +1,56 @@
+---
+name: gsd.quick
+description: "Execute a quick task with GSD guarantees (atomic commits, state tracking) but skip optional agents"
+argument-hint: "[--full]"
+tools: ['agent', 'edit', 'execute', 'read', 'search', 'vscode/askQuestions']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Edit","Glob","Grep","Bash","Task","AskUserQuestion"] -->
+
+## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an `AskUserQuestion` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named `AskUserQuestion`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+
+<objective>
+Execute small, ad-hoc tasks with GSD guarantees (atomic commits, STATE.md tracking).
+
+Quick mode is the same system with a shorter path:
+- Spawns gsd-planner (quick mode) + gsd-executor(s)
+- Quick tasks live in `.planning/quick/` separate from planned phases
+- Updates STATE.md "Quick Tasks Completed" table (NOT ROADMAP.md)
+
+**Default:** Skips research, plan-checker, verifier. Use when you know exactly what to do.
+
+**`--full` flag:** Enables plan-checking (max 2 iterations) and post-execution verification. Use when you want quality guarantees without full milestone ceremony.
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/quick.md
+</execution_context>
+
+<context>
+$ARGUMENTS
+
+Context files are resolved inside the workflow (`init quick`) and delegated via `<files_to_read>` blocks.
+</context>
+
+<process>
+Execute the quick workflow from @./.claude/get-shit-done/workflows/quick.md end-to-end.
+Preserve all workflow gates (validation, task description, planning, execution, state updates, commits).
+</process>

--- a/.github/prompts/gsd.reapply-patches.prompt.md
+++ b/.github/prompts/gsd.reapply-patches.prompt.md
@@ -1,0 +1,133 @@
+---
+name: gsd.reapply-patches
+description: "Reapply local modifications after a GSD update"
+tools: ['edit', 'execute', 'read', 'search', 'vscode/askQuestions']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Edit","Bash","Glob","Grep","AskUserQuestion"] -->
+
+## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an `AskUserQuestion` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named `AskUserQuestion`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+
+<purpose>
+After a GSD update wipes and reinstalls files, this command merges user's previously saved local modifications back into the new version. Uses intelligent comparison to handle cases where the upstream file also changed.
+</purpose>
+
+<process>
+
+## Step 1: Detect backed-up patches
+
+Check for local patches directory:
+
+```bash
+# Global install (path templated at install time)
+PATCHES_DIR=./.claude/gsd-local-patches
+# Local install fallback
+if [ ! -d "$PATCHES_DIR" ]; then
+  PATCHES_DIR=./.claude/gsd-local-patches
+fi
+```
+
+Read `backup-meta.json` from the patches directory.
+
+**If no patches found:**
+```
+No local patches found. Nothing to reapply.
+
+Local patches are automatically saved when you run /gsd:update
+after modifying any GSD workflow, command, or agent files.
+```
+Exit.
+
+## Step 2: Show patch summary
+
+```
+## Local Patches to Reapply
+
+**Backed up from:** v{from_version}
+**Current version:** {read VERSION file}
+**Files modified:** {count}
+
+| # | File | Status |
+|---|------|--------|
+| 1 | {file_path} | Pending |
+| 2 | {file_path} | Pending |
+```
+
+## Step 3: Merge each file
+
+For each file in `backup-meta.json`:
+
+1. **Read the backed-up version** (user's modified copy from `gsd-local-patches/`)
+2. **Read the newly installed version** (current file after update)
+3. **Compare and merge:**
+
+   - If the new file is identical to the backed-up file: skip (modification was incorporated upstream)
+   - If the new file differs: identify the user's modifications and apply them to the new version
+
+   **Merge strategy:**
+   - Read both versions fully
+   - Identify sections the user added or modified (look for additions, not just differences from path replacement)
+   - Apply user's additions/modifications to the new version
+   - If a section the user modified was also changed upstream: flag as conflict, show both versions, ask user which to keep
+
+4. **Write merged result** to the installed location
+5. **Report status:**
+   - `Merged` — user modifications applied cleanly
+   - `Skipped` — modification already in upstream
+   - `Conflict` — user chose resolution
+
+## Step 4: Update manifest
+
+After reapplying, regenerate the file manifest so future updates correctly detect these as user modifications:
+
+```bash
+# The manifest will be regenerated on next /gsd:update
+# For now, just note which files were modified
+```
+
+## Step 5: Cleanup option
+
+Ask user:
+- "Keep patch backups for reference?" → preserve `gsd-local-patches/`
+- "Clean up patch backups?" → remove `gsd-local-patches/` directory
+
+## Step 6: Report
+
+```
+## Patches Reapplied
+
+| # | File | Status |
+|---|------|--------|
+| 1 | {file_path} | ✓ Merged |
+| 2 | {file_path} | ○ Skipped (already upstream) |
+| 3 | {file_path} | ⚠ Conflict resolved |
+
+{count} file(s) updated. Your local modifications are active again.
+```
+
+</process>
+
+<success_criteria>
+- [ ] All backed-up patches processed
+- [ ] User modifications merged into new version
+- [ ] Conflicts resolved with user input
+- [ ] Status reported for each file
+</success_criteria>

--- a/.github/prompts/gsd.remove-phase.prompt.md
+++ b/.github/prompts/gsd.remove-phase.prompt.md
@@ -1,0 +1,31 @@
+---
+name: gsd.remove-phase
+description: "Remove a future phase from roadmap and renumber subsequent phases"
+argument-hint: "<phase-number>"
+tools: ['edit', 'execute', 'read', 'search']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Bash","Glob"] -->
+
+<objective>
+Remove an unstarted future phase from the roadmap and renumber all subsequent phases to maintain a clean, linear sequence.
+
+Purpose: Clean removal of work you've decided not to do, without polluting context with cancelled/deferred markers.
+Output: Phase deleted, all subsequent phases renumbered, git commit as historical record.
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/remove-phase.md
+</execution_context>
+
+<context>
+Phase: $ARGUMENTS
+
+Roadmap and state are resolved in-workflow via `init phase-op` and targeted reads.
+</context>
+
+<process>
+Execute the remove-phase workflow from @./.claude/get-shit-done/workflows/remove-phase.md end-to-end.
+Preserve all validation gates (future phase check, work check), renumbering logic, and commit.
+</process>

--- a/.github/prompts/gsd.research-phase.prompt.md
+++ b/.github/prompts/gsd.research-phase.prompt.md
@@ -1,0 +1,189 @@
+---
+name: gsd.research-phase
+description: "Research how to implement a phase (standalone - usually use /gsd:plan-phase instead)"
+argument-hint: "[phase]"
+tools: ['agent', 'execute', 'read']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Bash","Task"] -->
+
+<objective>
+Research how to implement a phase. Spawns gsd-phase-researcher agent with phase context.
+
+**Note:** This is a standalone research command. For most workflows, use `/gsd:plan-phase` which integrates research automatically.
+
+**Use this command when:**
+- You want to research without planning yet
+- You want to re-research after planning is complete
+- You need to investigate before deciding if a phase is feasible
+
+**Orchestrator role:** Parse phase, validate against roadmap, check existing research, gather context, spawn researcher agent, present results.
+
+**Why subagent:** Research burns context fast (WebSearch, Context7 queries, source verification). Fresh 200k context for investigation. Main context stays lean for user interaction.
+</objective>
+
+<context>
+Phase number: $ARGUMENTS (required)
+
+Normalize phase input in step 1 before any directory lookups.
+</context>
+
+<process>
+
+## 0. Initialize Context
+
+```bash
+INIT=$(node ./.claude/get-shit-done/bin/gsd-tools.cjs init phase-op "$ARGUMENTS")
+```
+
+Extract from init JSON: `phase_dir`, `phase_number`, `phase_name`, `phase_found`, `commit_docs`, `has_research`, `state_path`, `requirements_path`, `context_path`, `research_path`.
+
+Resolve researcher model:
+```bash
+RESEARCHER_MODEL=$(node ./.claude/get-shit-done/bin/gsd-tools.cjs resolve-model gsd-phase-researcher --raw)
+```
+
+## 1. Validate Phase
+
+```bash
+PHASE_INFO=$(node ./.claude/get-shit-done/bin/gsd-tools.cjs roadmap get-phase "${phase_number}")
+```
+
+**If `found` is false:** Error and exit. **If `found` is true:** Extract `phase_number`, `phase_name`, `goal` from JSON.
+
+## 2. Check Existing Research
+
+```bash
+ls .planning/phases/${PHASE}-*/RESEARCH.md 2>/dev/null
+```
+
+**If exists:** Offer: 1) Update research, 2) View existing, 3) Skip. Wait for response.
+
+**If doesn't exist:** Continue.
+
+## 3. Gather Phase Context
+
+Use paths from INIT (do not inline file contents in orchestrator context):
+- `requirements_path`
+- `context_path`
+- `state_path`
+
+Present summary with phase description and what files the researcher will load.
+
+## 4. Spawn gsd-phase-researcher Agent
+
+Research modes: ecosystem (default), feasibility, implementation, comparison.
+
+```markdown
+<research_type>
+Phase Research — investigating HOW to implement a specific phase well.
+</research_type>
+
+<key_insight>
+The question is NOT "which library should I use?"
+
+The question is: "What do I not know that I don't know?"
+
+For this phase, discover:
+- What's the established architecture pattern?
+- What libraries form the standard stack?
+- What problems do people commonly hit?
+- What's SOTA vs what Claude's training thinks is SOTA?
+- What should NOT be hand-rolled?
+</key_insight>
+
+<objective>
+Research implementation approach for Phase {phase_number}: {phase_name}
+Mode: ecosystem
+</objective>
+
+<files_to_read>
+- {requirements_path} (Requirements)
+- {context_path} (Phase context from discuss-phase, if exists)
+- {state_path} (Prior project decisions and blockers)
+</files_to_read>
+
+<additional_context>
+**Phase description:** {phase_description}
+</additional_context>
+
+<downstream_consumer>
+Your RESEARCH.md will be loaded by `/gsd:plan-phase` which uses specific sections:
+- `## Standard Stack` → Plans use these libraries
+- `## Architecture Patterns` → Task structure follows these
+- `## Don't Hand-Roll` → Tasks NEVER build custom solutions for listed problems
+- `## Common Pitfalls` → Verification steps check for these
+- `## Code Examples` → Task actions reference these patterns
+
+Be prescriptive, not exploratory. "Use X" not "Consider X or Y."
+</downstream_consumer>
+
+<quality_gate>
+Before declaring complete, verify:
+- [ ] All domains investigated (not just some)
+- [ ] Negative claims verified with official docs
+- [ ] Multiple sources for critical claims
+- [ ] Confidence levels assigned honestly
+- [ ] Section names match what plan-phase expects
+</quality_gate>
+
+<output>
+Write to: .planning/phases/${PHASE}-{slug}/${PHASE}-RESEARCH.md
+</output>
+```
+
+```
+Task(
+  prompt="First, read ./.claude/agents/gsd-phase-researcher.md for your role and instructions.\n\n" + filled_prompt,
+  subagent_type="general-purpose",
+  model="{researcher_model}",
+  description="Research Phase {phase}"
+)
+```
+
+## 5. Handle Agent Return
+
+**`## RESEARCH COMPLETE`:** Display summary, offer: Plan phase, Dig deeper, Review full, Done.
+
+**`## CHECKPOINT REACHED`:** Present to user, get response, spawn continuation.
+
+**`## RESEARCH INCONCLUSIVE`:** Show what was attempted, offer: Add context, Try different mode, Manual.
+
+## 6. Spawn Continuation Agent
+
+```markdown
+<objective>
+Continue research for Phase {phase_number}: {phase_name}
+</objective>
+
+<prior_state>
+<files_to_read>
+- .planning/phases/${PHASE}-{slug}/${PHASE}-RESEARCH.md (Existing research)
+</files_to_read>
+</prior_state>
+
+<checkpoint_response>
+**Type:** {checkpoint_type}
+**Response:** {user_response}
+</checkpoint_response>
+```
+
+```
+Task(
+  prompt="First, read ./.claude/agents/gsd-phase-researcher.md for your role and instructions.\n\n" + continuation_prompt,
+  subagent_type="general-purpose",
+  model="{researcher_model}",
+  description="Continue research Phase {phase}"
+)
+```
+
+</process>
+
+<success_criteria>
+- [ ] Phase validated against roadmap
+- [ ] Existing research checked
+- [ ] gsd-phase-researcher spawned with context
+- [ ] Checkpoints handled correctly
+- [ ] User knows next steps
+</success_criteria>

--- a/.github/prompts/gsd.resume-work.prompt.md
+++ b/.github/prompts/gsd.resume-work.prompt.md
@@ -1,0 +1,58 @@
+---
+name: gsd.resume-work
+description: "Resume work from previous session with full context restoration"
+tools: ['edit', 'execute', 'read', 'vscode/askQuestions']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Bash","Write","AskUserQuestion","SlashCommand"] -->
+<!-- omitted-tools: ["slashcommand"] — no Copilot equivalent found -->
+
+## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an `AskUserQuestion` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named `AskUserQuestion`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+
+<objective>
+Restore complete project context and resume work seamlessly from previous session.
+
+Routes to the resume-project workflow which handles:
+
+- STATE.md loading (or reconstruction if missing)
+- Checkpoint detection (.continue-here files)
+- Incomplete work detection (PLAN without SUMMARY)
+- Status presentation
+- Context-aware next action routing
+  </objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/resume-project.md
+</execution_context>
+
+<process>
+**Follow the resume-project workflow** from `@./.claude/get-shit-done/workflows/resume-project.md`.
+
+The workflow handles all resumption logic including:
+
+1. Project existence verification
+2. STATE.md loading or reconstruction
+3. Checkpoint and incomplete work detection
+4. Visual status presentation
+5. Context-aware option offering (checks CONTEXT.md before suggesting plan vs discuss)
+6. Routing to appropriate next command
+7. Session continuity updates
+   </process>

--- a/.github/prompts/gsd.set-profile.prompt.md
+++ b/.github/prompts/gsd.set-profile.prompt.md
@@ -1,0 +1,34 @@
+---
+name: gsd.set-profile
+description: "Switch model profile for GSD agents (quality/balanced/budget)"
+argument-hint: "<profile>"
+tools: ['edit', 'execute', 'read']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Bash"] -->
+
+<objective>
+Switch the model profile used by GSD agents. Controls which Claude model each agent uses, balancing quality vs token spend.
+
+Routes to the set-profile workflow which handles:
+- Argument validation (quality/balanced/budget)
+- Config file creation if missing
+- Profile update in config.json
+- Confirmation with model table display
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/set-profile.md
+</execution_context>
+
+<process>
+**Follow the set-profile workflow** from `@./.claude/get-shit-done/workflows/set-profile.md`.
+
+The workflow handles all logic including:
+1. Profile argument validation
+2. Config file ensuring
+3. Config reading and updating
+4. Model table generation from MODEL_PROFILES
+5. Confirmation display
+</process>

--- a/.github/prompts/gsd.settings.prompt.md
+++ b/.github/prompts/gsd.settings.prompt.md
@@ -1,0 +1,54 @@
+---
+name: gsd.settings
+description: "Configure GSD workflow toggles and model profile"
+tools: ['edit', 'execute', 'read', 'vscode/askQuestions']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Write","Bash","AskUserQuestion"] -->
+
+## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an `AskUserQuestion` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named `AskUserQuestion`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+
+<objective>
+Interactive configuration of GSD workflow agents and model profile via multi-question prompt.
+
+Routes to the settings workflow which handles:
+- Config existence ensuring
+- Current settings reading and parsing
+- Interactive 5-question prompt (model, research, plan_check, verifier, branching)
+- Config merging and writing
+- Confirmation display with quick command references
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/settings.md
+</execution_context>
+
+<process>
+**Follow the settings workflow** from `@./.claude/get-shit-done/workflows/settings.md`.
+
+The workflow handles all logic including:
+1. Config file creation with defaults if missing
+2. Current config reading
+3. Interactive settings presentation with pre-selection
+4. Answer parsing and config merging
+5. File writing
+6. Confirmation display
+</process>

--- a/.github/prompts/gsd.update.prompt.md
+++ b/.github/prompts/gsd.update.prompt.md
@@ -1,0 +1,57 @@
+---
+name: gsd.update
+description: "Update GSD to latest version with changelog display"
+tools: ['execute', 'vscode/askQuestions']
+agent: agent
+---
+
+<!-- upstream-tools: ["Bash","AskUserQuestion"] -->
+
+## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an `AskUserQuestion` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named `AskUserQuestion`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+
+<objective>
+Check for GSD updates, install if available, and display what changed.
+
+Routes to the update workflow which handles:
+- Version detection (local vs global installation)
+- npm version checking
+- Changelog fetching and display
+- User confirmation with clean install warning
+- Update execution and cache clearing
+- Restart reminder
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/update.md
+</execution_context>
+
+<process>
+**Follow the update workflow** from `@./.claude/get-shit-done/workflows/update.md`.
+
+The workflow handles all logic including:
+1. Installed version detection (local/global)
+2. Latest version checking via npm
+3. Version comparison
+4. Changelog fetching and extraction
+5. Clean install warning display
+6. User confirmation
+7. Update execution
+8. Cache clearing
+</process>

--- a/.github/prompts/gsd.verify-work.prompt.md
+++ b/.github/prompts/gsd.verify-work.prompt.md
@@ -1,0 +1,35 @@
+---
+name: gsd.verify-work
+description: "Validate built features through conversational UAT"
+argument-hint: "[phase number, e.g., '4']"
+tools: ['agent', 'edit', 'execute', 'read', 'search']
+agent: agent
+---
+
+<!-- upstream-tools: ["Read","Bash","Glob","Grep","Edit","Write","Task"] -->
+
+<objective>
+Validate built features through conversational testing with persistent state.
+
+Purpose: Confirm what Claude built actually works from user's perspective. One test at a time, plain text responses, no interrogation. When issues are found, automatically diagnose, plan fixes, and prepare for execution.
+
+Output: {phase_num}-UAT.md tracking all test results. If issues found: diagnosed gaps, verified fix plans ready for /gsd:execute-phase
+</objective>
+
+<execution_context>
+- Read file at: ./.claude/get-shit-done/workflows/verify-work.md
+- Read file at: ./.claude/get-shit-done/templates/UAT.md
+</execution_context>
+
+<context>
+Phase: $ARGUMENTS (optional)
+- If provided: Test specific phase (e.g., "4")
+- If not provided: Check for active sessions or prompt for phase
+
+Context files are resolved inside the workflow (`init verify-work`) and delegated via `<files_to_read>` blocks.
+</context>
+
+<process>
+Execute the verify-work workflow from @./.claude/get-shit-done/workflows/verify-work.md end-to-end.
+Preserve all workflow gates (session management, test presentation, diagnosis, fix planning, routing).
+</process>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,126 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  EXPECTED_REPO: maitaitime/get-shit-done-github-copilot
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    steps:
+      # SAFETY: Always run this assertion first. Add --repo "$GITHUB_REPOSITORY" to any new gh command you add here.
+      - name: Assert fork context
+        run: |
+          if [ "$GITHUB_REPOSITORY" != "${{ env.EXPECTED_REPO }}" ]; then
+            echo "ERROR: This workflow is running on '$GITHUB_REPOSITORY' but is only intended to run on '${{ env.EXPECTED_REPO }}'."
+            echo "Refusing to proceed — this prevents accidental writes to the wrong repository."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build zip artifact
+        run: |
+          # --- Create staging directory structure ---
+          mkdir -p staging/.github/prompts
+          mkdir -p staging/.github/instructions
+          mkdir -p staging/.claude/commands/gsd
+          mkdir -p staging/.claude/get-shit-done
+          mkdir -p staging/.claude/agents
+          mkdir -p staging/.claude/hooks
+          mkdir -p staging/gsd-copilot-installer
+
+          # --- Copilot layer: .github/ files ---
+
+          # Prompts
+          cp -r .github/prompts/. staging/.github/prompts/
+
+          # GSD-prefixed instruction files only (|| true: dir may be empty or missing)
+          find .github/instructions -maxdepth 1 \( -name "gsd-*.instructions.md" -o -name "gsd.*.md" \) \
+            -exec cp {} staging/.github/instructions/ \; 2>/dev/null || true
+
+          # NOTE: .github/agents/ is intentionally omitted — it is empty by design.
+
+          # --- Upstream runtime: .claude/ ---
+
+          # Commands
+          cp -r commands/gsd/. staging/.claude/commands/gsd/
+
+          # Get-shit-done runtime tree
+          cp -r get-shit-done/. staging/.claude/get-shit-done/
+
+          # Agents
+          cp -r agents/. staging/.claude/agents/
+
+          # Hooks (.js files only — || true: tolerates empty or missing dir)
+          find hooks -maxdepth 1 -name "*.js" -exec cp {} staging/.claude/hooks/ \; 2>/dev/null || true
+
+          # --- CommonJS mode marker ---
+          echo '{"type":"commonjs"}' > staging/.claude/package.json
+
+          # --- Installer files ---
+          cp gsd-copilot-installer/gsd-copilot-install.ps1 staging/gsd-copilot-installer/gsd-copilot-install.ps1
+          cp gsd-copilot-installer/README.md   staging/gsd-copilot-installer/README.md
+
+          # --- Path replacement: rewrite ~/.claude/ → ./.claude/ in all .md files ---
+          find staging/.claude -name "*.md" -exec sed -i 's|~/.claude/|./.claude/|g' {} \;
+
+          # --- Zip flat-at-root (paths inside zip start at .github/, .claude/, etc.) ---
+          cd staging && zip -r ../gsd-copilot-${{ github.ref_name }}.zip .
+
+      - name: Validate zip contents
+        run: |
+          echo "Validating zip contents..."
+          ZIP="gsd-copilot-${{ github.ref_name }}.zip"
+
+          fail=0
+
+          check_path() {
+            local label="$1"
+            local pattern="$2"
+            if unzip -l "$ZIP" | grep -q "$pattern"; then
+              echo "  ✓ $label"
+            else
+              echo "  ✗ MISSING: $label ($pattern)"
+              fail=1
+            fi
+          }
+
+          check_path ".github/prompts/"                        ".github/prompts/"
+          check_path ".claude/commands/gsd/"                   ".claude/commands/gsd/"
+          check_path ".claude/get-shit-done/workflows/"        ".claude/get-shit-done/workflows/"
+          check_path ".claude/agents/"                         ".claude/agents/"
+          check_path ".claude/hooks/"                          ".claude/hooks/"
+          check_path ".claude/get-shit-done/bin/gsd-tools.cjs" ".claude/get-shit-done/bin/gsd-tools.cjs"
+          check_path ".claude/package.json"                    ".claude/package.json"
+          check_path "at least one .prompt.md"                 "\.prompt\.md"
+
+          if [ "$fail" -eq 1 ]; then
+            echo ""
+            echo "Release blocked: zip is missing required paths. See errors above."
+            exit 1
+          fi
+
+          echo "All zip contents validated."
+
+      - name: Create GitHub Release and upload asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            ./gsd-copilot-${{ github.ref_name }}.zip \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "GSD Copilot ${{ github.ref_name }}" \
+            --generate-notes

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,2010 @@
+# Upstream Sync + Release Mirror Workflow
+# Detects changes in upstream gsd-build/get-shit-done, merges them,
+# regenerates the Copilot wrapper layer, verifies it, and creates/updates a PR.
+# Also polls upstream for new releases and auto-publishes a matching fork release.
+#
+# One-time prerequisites (run once before first execution):
+#   gh label create upstream-sync --color 0075ca --description "Upstream sync PR" --repo <fork>
+#   gh label create automated --color e4e669 --description "Automated workflow" --repo <fork>
+#   gh label create upstream-mirror --color d93f0b --description "Upstream release mirror" --repo <fork>
+#   gh label create escalation --color d93f0b --description "Escalation required: autonomous maintenance dead-end" --repo <fork>
+#   Enable: Settings → General → Pull Requests → Allow auto-merge: ON
+#   Verify: COPILOT_PAT secret has 'repo' scope (required for tag push to trigger release.yml)
+#
+# Schedule: runs every 4 hours. Both sync and release-mirror jobs exit silently when nothing to do.
+
+on:
+  schedule:
+    - cron: '0 */4 * * *'  # Every 4 hours (00:00, 04:00, 08:00, 12:00, 16:00, 20:00 UTC)
+  workflow_dispatch:
+  push:
+    branches:
+      - 'copilot/**'
+
+name: Upstream Sync
+
+concurrency:
+  group: upstream-sync
+  cancel-in-progress: false
+
+env:
+  DEFAULT_BRANCH: main
+  EXPECTED_REPO: maitaitime/get-shit-done-github-copilot
+  UPSTREAM_BRANCH: main
+  UPSTREAM_REPO: gsd-build/get-shit-done
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    outputs:
+      security_flagged: ${{ steps.analyze_delta.outputs.security_flagged }}
+      has_new_commands: ${{ steps.analyze_delta.outputs.has_new_commands }}
+      no_changes: ${{ steps.detect.outputs.no_changes }}
+      short_sha: ${{ steps.detect.outputs.short_sha }}
+      merge_conflict: ${{ steps.merge.outputs.merge_conflict }}
+      merge_conflict_files: ${{ steps.merge.outputs.merge_conflict_files }}
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      # SAFETY: Always run this assertion first. Add --repo "$GITHUB_REPOSITORY" to any new gh command you add here.
+      - name: Assert fork context
+        run: |
+          if [ "$GITHUB_REPOSITORY" != "${{ env.EXPECTED_REPO }}" ]; then
+            echo "ERROR: This workflow is running on '$GITHUB_REPOSITORY' but is only intended to run on '${{ env.EXPECTED_REPO }}'."
+            echo "Refusing to proceed — this prevents accidental writes to the wrong repository."
+            exit 1
+          fi
+
+      - name: Checkout fork (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote and fetch
+        run: |
+          git remote add upstream "https://github.com/${{ env.UPSTREAM_REPO }}.git" || true
+          git fetch upstream "${{ env.UPSTREAM_BRANCH }}"
+
+      - name: Detect upstream changes
+        id: detect
+        run: |
+          FORK_HEAD=$(git rev-parse HEAD)
+          UPSTREAM_HEAD=$(git rev-parse "upstream/${{ env.UPSTREAM_BRANCH }}")
+          SHORT_SHA=$(git rev-parse --short "upstream/${{ env.UPSTREAM_BRANCH }}")
+
+          echo "fork_head=$FORK_HEAD" >> "$GITHUB_OUTPUT"
+          echo "upstream_head=$UPSTREAM_HEAD" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+
+          # Check if upstream has commits not in fork HEAD
+          DIFF_COUNT=$(git rev-list HEAD..upstream/${{ env.UPSTREAM_BRANCH }} --count)
+          if [ "$DIFF_COUNT" -eq 0 ]; then
+            echo "no_changes=true" >> "$GITHUB_OUTPUT"
+            echo "No upstream changes detected. Exiting."
+          else
+            echo "no_changes=false" >> "$GITHUB_OUTPUT"
+            echo "Detected $DIFF_COUNT new upstream commit(s)."
+          fi
+
+      - name: Exit silently if no changes
+        if: steps.detect.outputs.no_changes == 'true'
+        run: exit 0
+
+      - name: Create/reset working branch
+        if: steps.detect.outputs.no_changes != 'true'
+        run: |
+          git checkout -B automated/upstream-sync origin/${{ env.DEFAULT_BRANCH }}
+
+      - name: Merge upstream changes
+        if: steps.detect.outputs.no_changes != 'true'
+        id: merge
+        run: |
+          echo "merge_conflict=false" >> "$GITHUB_OUTPUT"
+          CONFLICT_SHA="${{ steps.detect.outputs.short_sha }}"
+
+          # Ensure upstream-sync label exists
+          gh label create "upstream-sync" \
+            --color "0075ca" \
+            --description "Upstream sync automation" \
+            --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+
+          if git merge "upstream/${{ env.UPSTREAM_BRANCH }}" --no-edit; then
+            echo "Merge succeeded cleanly."
+
+            # Close any open conflict issue for this upstream SHA
+            OPEN_CONFLICT=$(gh issue list \
+              --repo "$GITHUB_REPOSITORY" \
+              --label "upstream-sync" \
+              --state open \
+              --search "\"Upstream sync merge conflict (upstream@${CONFLICT_SHA})\" in:title" \
+              --json number \
+              --jq '.[0].number' 2>/dev/null || echo "")
+            if [ -n "$OPEN_CONFLICT" ] && [ "$OPEN_CONFLICT" != "null" ]; then
+              echo "Closing resolved conflict issue #${OPEN_CONFLICT}..."
+              gh issue close "$OPEN_CONFLICT" \
+                --repo "$GITHUB_REPOSITORY" \
+                --comment "Closed automatically: upstream@${CONFLICT_SHA} merged successfully in run ${{ github.run_id }}."
+            fi
+
+            exit 0
+          fi
+
+          echo "Merge conflict detected. Attempting auto-resolution by file ownership..."
+
+          # Guard: if there are no unmerged files, the failure was not conflict-related.
+          # Emit merge_conflict=false and abort so the repair job handles it as a generic failure.
+          CONFLICT_FILES=$(git diff --name-only --diff-filter=U)
+          if [ -z "$CONFLICT_FILES" ]; then
+            echo "::error::git merge failed but no unmerged files detected — non-conflict merge failure."
+            exit 1
+          fi
+
+          # Fork-owned files: --ours always wins
+          FORK_OWNED_PATTERN="^(package\.json|README\.md|FORK-CHANGELOG\.md|AGENTS\.md|FUNDING\.yml|\.github/FUNDING\.yml|\.github/ISSUE_TEMPLATE/bug_report\.yml|\.github/workflows/[^/]+\.yml|\.github/prompts/.*|\.github/agents/.*|\.github/instructions/.*|\.github/copilot-instructions\.md|\.planning/.*)$"
+
+          for f in $CONFLICT_FILES; do
+            if echo "$f" | grep -qE "$FORK_OWNED_PATTERN"; then
+              echo "Auto-resolving (--ours): $f"
+              git checkout --ours "$f"
+              git add "$f"
+            elif [ "$f" = "CHANGELOG.md" ]; then
+              echo "Auto-resolving (--theirs): $f (upstream-owned)"
+              git checkout --theirs "$f"
+              git add "$f"
+            else
+              echo "Cannot auto-resolve: $f"
+            fi
+          done
+
+          REMAINING=$(git diff --name-only --diff-filter=U)
+
+          if [ -z "$REMAINING" ]; then
+            echo "All conflicts auto-resolved. Committing merge..."
+            git commit -m "chore: merge upstream/main (auto-resolved fork-owned conflicts)"
+            echo "merge_conflict=false" >> "$GITHUB_OUTPUT"
+
+            # Close any open conflict issue for this SHA — same logic as clean merge path
+            OPEN_CONFLICT=$(gh issue list \
+              --repo "$GITHUB_REPOSITORY" \
+              --label "upstream-sync" \
+              --state open \
+              --search "\"Upstream sync merge conflict (upstream@${CONFLICT_SHA})\" in:title" \
+              --json number \
+              --jq '.[0].number' 2>/dev/null || echo "")
+            if [ -n "$OPEN_CONFLICT" ] && [ "$OPEN_CONFLICT" != "null" ]; then
+              echo "Closing resolved conflict issue #${OPEN_CONFLICT}..."
+              gh issue close "$OPEN_CONFLICT" \
+                --repo "$GITHUB_REPOSITORY" \
+                --comment "Closed automatically: upstream@${CONFLICT_SHA} auto-resolved in run ${{ github.run_id }}."
+            fi
+
+            exit 0
+          fi
+
+          echo "Unresolvable conflicts remain: $REMAINING"
+          echo "merge_conflict=true" >> "$GITHUB_OUTPUT"
+          CONFLICT_LIST=$(echo "$REMAINING" | tr '\n' ',' | sed 's/,$//')
+          echo "merge_conflict_files=${CONFLICT_LIST}" >> "$GITHUB_OUTPUT"
+          exit 1
+
+      - name: Report merge conflict
+        if: steps.detect.outputs.no_changes != 'true' && steps.merge.outputs.merge_conflict == 'true'
+        run: |
+          CONFLICT_SHA="${{ steps.detect.outputs.short_sha }}"
+
+          # Ensure upstream-sync label exists
+          gh label create "upstream-sync" \
+            --color "0075ca" \
+            --description "Upstream sync automation" \
+            --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+
+          # Dedup check: existing open issue for this SHA?
+          EXISTING_ISSUE=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label "upstream-sync" \
+            --state open \
+            --search "\"Upstream sync merge conflict (upstream@${CONFLICT_SHA})\" in:title" \
+            --json number \
+            --jq '.[0].number' 2>/dev/null || echo "")
+
+          git diff --name-only --diff-filter=U > /tmp/conflict-files.txt
+
+          cat > /tmp/conflict-body.md << 'ISSUE_EOF'
+          ## Upstream Sync Merge Conflict
+
+          The automated upstream sync encountered a merge conflict that could not be auto-resolved.
+          ISSUE_EOF
+
+          cat >> /tmp/conflict-body.md << ISSUE_EOF
+
+          **Upstream commit:** ${{ steps.detect.outputs.short_sha }}
+          **Upstream HEAD:** ${{ steps.detect.outputs.upstream_head }}
+          **Fork HEAD (before merge):** ${{ steps.detect.outputs.fork_head }}
+          ISSUE_EOF
+
+          cat >> /tmp/conflict-body.md << 'ISSUE_EOF'
+
+          ### Conflicting files (not auto-resolvable)
+          ISSUE_EOF
+          cat /tmp/conflict-files.txt | sed 's/^/- /' >> /tmp/conflict-body.md
+          cat >> /tmp/conflict-body.md << ISSUE_EOF
+
+          The repair agent will attempt to resolve this. If it cannot, an escalation issue will be filed separately.
+
+          **Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ISSUE_EOF
+
+          if [ -n "$EXISTING_ISSUE" ] && [ "$EXISTING_ISSUE" != "null" ]; then
+            echo "Conflict issue #${EXISTING_ISSUE} already open. Appending comment."
+            gh issue comment "$EXISTING_ISSUE" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body-file /tmp/conflict-body.md
+          else
+            echo "Creating new conflict issue..."
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Upstream sync merge conflict (upstream@${CONFLICT_SHA})" \
+              --body-file /tmp/conflict-body.md \
+              --label "upstream-sync"
+          fi
+
+      - name: Analyze upstream delta
+        if: steps.detect.outputs.no_changes != 'true' && steps.merge.outcome == 'success'
+        id: analyze_delta
+        run: |
+          FORK_HEAD="${{ steps.detect.outputs.fork_head }}"
+          UPSTREAM_HEAD="${{ steps.detect.outputs.upstream_head }}"
+
+          # Structural diff — what files changed in upstream-owned dirs
+          STRUCT_DIFF=$(git diff --name-status "$FORK_HEAD" "$UPSTREAM_HEAD" \
+            -- commands/gsd/ agents/ get-shit-done/ 2>/dev/null || echo "")
+
+          # Upstream commit log
+          UPSTREAM_LOG=$(git log --oneline "$FORK_HEAD..upstream/${{ env.UPSTREAM_BRANCH }}" 2>/dev/null || echo "(none)")
+
+          # Detect new commands (status A = Added) in commands/gsd/
+          NEW_COMMANDS=$(echo "$STRUCT_DIFF" | awk '$1=="A"{print $2}' | grep 'commands/gsd/' || echo "")
+          if [ -n "$NEW_COMMANDS" ]; then
+            echo "has_new_commands=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_new_commands=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Detect new agents
+          NEW_AGENTS=$(echo "$STRUCT_DIFF" | awk '$1=="A"{print $2}' | grep 'agents/' || echo "")
+
+          # Security scan: YAML files only (avoids false positives on doc lines)
+          YAML_DIFF=$(git diff "$FORK_HEAD" "$UPSTREAM_HEAD" -- "*.yml" "*.yaml" 2>/dev/null || echo "")
+          SECURITY_HITS=$(echo "$YAML_DIFF" | \
+            grep -E "^[+-].*\b(GITHUB_TOKEN|secrets\.|permissions:|token:|auth:)\b" | \
+            grep -v "^---\|^+++" | head -20 || echo "")
+          if [ -n "$SECURITY_HITS" ]; then
+            echo "security_flagged=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Security-sensitive upstream YAML changes detected. Auto-merge will be blocked."
+          else
+            echo "security_flagged=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Content diff of upstream dirs (truncated to 30k chars for agent context)
+          CONTENT_DIFF=$(git diff "$FORK_HEAD" "$UPSTREAM_HEAD" \
+            -- commands/gsd/ agents/ get-shit-done/ 2>/dev/null | head -c 30000 || echo "")
+
+          # Write structured analysis to /tmp for downstream consumption
+          cat > /tmp/delta-analysis.md << 'DELIM'
+          ## Upstream Delta Analysis
+          DELIM
+
+          cat >> /tmp/delta-analysis.md << DELIM
+          **Upstream commits:**
+          \`\`\`
+          ${UPSTREAM_LOG}
+          \`\`\`
+
+          **Structural changes (upstream-owned dirs):**
+          \`\`\`
+          ${STRUCT_DIFF:-"(none)"}
+          \`\`\`
+
+          **New commands detected:** ${NEW_COMMANDS:-"(none)"}
+          **New agents detected:** ${NEW_AGENTS:-"(none)"}
+          **Security-sensitive YAML lines:** ${SECURITY_HITS:-"(none)"}
+
+          **Content diff (truncated to 30k chars):**
+          \`\`\`diff
+          ${CONTENT_DIFF:-"(none)"}
+          \`\`\`
+          DELIM
+
+          echo "Delta analysis written to /tmp/delta-analysis.md"
+
+          # Write full analysis to workflow step summary
+          echo "## Upstream Delta Analysis (upstream@${{ steps.detect.outputs.short_sha }})" >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/delta-analysis.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Proactive fork adaptation
+        if: steps.detect.outputs.no_changes != 'true' && steps.merge.outcome == 'success'
+        id: proactive_adapt
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_PAT }}
+        run: |
+          # Skip gracefully if COPILOT_PAT is not set
+          if [ -z "$GH_TOKEN" ]; then
+            echo "COPILOT_PAT not configured — skipping proactive adaptation."
+            echo "proactive_adapt_invoked=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          DELTA_ANALYSIS=$(cat /tmp/delta-analysis.md 2>/dev/null || echo "(delta analysis unavailable)")
+          HAS_NEW_COMMANDS="${{ steps.analyze_delta.outputs.has_new_commands }}"
+
+          # Build gap-filling addendum if new commands/agents detected
+          GAP_INSTRUCTIONS=""
+          if [ "${HAS_NEW_COMMANDS}" = "true" ]; then
+            GAP_INSTRUCTIONS="
+          ## Coverage Gap Filling (REQUIRED)
+
+          New upstream commands or agents were detected with no fork equivalents.
+          For each new file listed under 'New commands detected' or 'New agents detected' in the delta analysis above:
+          1. Create a corresponding wrapper prompt in .github/prompts/ following the exact format of existing prompts.
+          2. Run node scripts/verify-prompts.mjs after creating wrappers to confirm coverage.
+          3. If scripts/verify-prompts.mjs reports any 'missing prompt' errors, fix them before finishing.
+          "
+          fi
+
+          cat > /tmp/proactive_prompt.md << PROMPT_EOF
+          You are the GSD upstream-sync proactive adaptation agent. An upstream merge just landed. Analyze the delta below and make ALL required changes to keep the fork's compatibility layer working correctly.
+
+          ## Authority — what you MAY modify
+          - scripts/generate-prompts.mjs
+          - scripts/verify-prompts.mjs
+          - scripts/tools.json
+          - .github/workflows/upstream-sync.yml
+          - .github/prompts/**
+          - .github/agents/**
+          - .github/instructions/**
+          - README.md
+          - FORK-CHANGELOG.md
+          - AGENTS.md
+
+          ## Hard limit — NEVER modify
+          - commands/gsd/**
+          - agents/**
+          - get-shit-done/**
+
+          ## Required outcome
+          1. Make any pre-emptive changes needed based on the upstream delta (e.g., if upstream added a new frontmatter field, update generate-prompts.mjs to handle it).
+          2. Run: node scripts/generate-prompts.mjs && node scripts/verify-prompts.mjs
+          3. Both must pass.
+          4. Open a PR targeting branch: automated/upstream-sync
+          5. Write a descriptive commit message explaining WHAT you changed and WHY.
+          6. If you determine that no changes are needed (everything already works), make no commits.
+          7. If you determine this problem requires human input, write "DEAD_END" to /tmp/repair-dead-end.txt and stop.
+
+          ${GAP_INSTRUCTIONS}
+
+          ## Upstream Delta Analysis
+          ${DELTA_ANALYSIS}
+          PROMPT_EOF
+
+          # Trigger Copilot coding agent via issue assignment.
+          # gh agent-task create cannot be used in CI — it requires an interactive
+          # OAuth token (browser/device flow) regardless of PAT scopes.
+          # In this repository, we trigger the Copilot coding agent by creating a
+          # GitHub issue assigned to 'copilot'; when enabled, the agent should pick
+          # it up and open a copilot/* PR. This behavior depends on repository
+          # Trigger Copilot coding agent via issue assignment.
+          # Issue is created first (no assignee) to guarantee the issue exists
+          # and the prompt is captured even if Copilot assignment fails.
+          # Assignment is attempted separately so the real API error is visible.
+          echo "Creating Copilot adaptation issue..."
+          ADAPT_ISSUE_URL=$(gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "adapt(upstream-sync): proactive fork adaptation [$(date -u +%Y-%m-%dT%H:%M)]" \
+            --body-file /tmp/proactive_prompt.md \
+            --label "upstream-sync" \
+            2>&1) || true
+          echo "gh issue create output: $ADAPT_ISSUE_URL"
+          ADAPT_ISSUE=$(echo "$ADAPT_ISSUE_URL" | grep -oP '/issues/\K[0-9]+' || echo "")
+          [[ "$ADAPT_ISSUE" =~ ^[0-9]+$ ]] || ADAPT_ISSUE=""
+
+          if [ -z "$ADAPT_ISSUE" ]; then
+            echo "::warning::Failed to create Copilot adaptation issue (see output above)."
+            echo "proactive_adapt_invoked=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Assigning Copilot coding agent to issue #${ADAPT_ISSUE}..."
+          ASSIGN_OUT=$(gh issue edit "$ADAPT_ISSUE" \
+            --repo "$GITHUB_REPOSITORY" \
+            --add-assignee "Copilot" \
+            2>&1) || true
+          echo "gh issue edit (assignee) output: $ASSIGN_OUT"
+
+          ISSUE_CREATED_AT=$(gh issue view "$ADAPT_ISSUE" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json createdAt \
+            --jq '.createdAt' 2>/dev/null || echo "")
+
+          if [ -z "$ISSUE_CREATED_AT" ]; then
+            echo "::warning::Failed to retrieve creation time for issue #${ADAPT_ISSUE}. Proceeding without PR association filter."
+          fi
+
+          echo "Created issue #${ADAPT_ISSUE}. Waiting up to 20 minutes for Copilot coding agent to open a PR..."
+          POLL_MAX=24
+          POLL_COUNT=0
+          ADAPT_PR=""
+          while [ $POLL_COUNT -lt $POLL_MAX ]; do
+            if [ -n "$ISSUE_CREATED_AT" ]; then
+              export ISSUE_CREATED_AT
+              ADAPT_PR=$(gh pr list \
+                --repo "$GITHUB_REPOSITORY" \
+                --base "automated/upstream-sync" \
+                --state open \
+                --json number,headRefName,createdAt \
+                --jq '.[] | select((.headRefName | startswith("copilot/")) and (.createdAt >= env.ISSUE_CREATED_AT)) | .number' \
+                2>/dev/null | head -1 || echo "")
+            else
+              ADAPT_PR=$(gh pr list \
+                --repo "$GITHUB_REPOSITORY" \
+                --base "automated/upstream-sync" \
+                --state open \
+                --json number,headRefName \
+                --jq '.[] | select(.headRefName | startswith("copilot/")) | .number' \
+                2>/dev/null | head -1 || echo "")
+            fi
+            if [ -n "$ADAPT_PR" ]; then
+              echo "Copilot PR #${ADAPT_PR} found after ~$((POLL_COUNT * 50))s."
+              break
+            fi
+            sleep 50
+            POLL_COUNT=$((POLL_COUNT + 1))
+          done
+
+          if [ -n "${ADAPT_PR:-}" ]; then
+            gh issue close "$ADAPT_ISSUE" \
+              --repo "$GITHUB_REPOSITORY" \
+              --comment "Processed by upstream-sync proactive adaptation step." \
+              2>/dev/null || true
+          else
+            echo "::warning::Copilot coding agent did not open a PR within 20 minutes. Leaving issue #${ADAPT_ISSUE} open."
+          fi
+
+          echo "proactive_adapt_invoked=true" >> "$GITHUB_OUTPUT"
+
+      - name: Merge Copilot adaptation branch
+        if: >
+          steps.detect.outputs.no_changes != 'true' &&
+          steps.merge.outcome == 'success' &&
+          steps.proactive_adapt.outputs.proactive_adapt_invoked == 'true'
+        id: merge_copilot_adapt
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_PAT }}
+        run: |
+          # Find open PR from copilot/* branch targeting automated/upstream-sync
+          COPILOT_PR=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --base "automated/upstream-sync" \
+            --state open \
+            --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("copilot/")) | .number' \
+            2>/dev/null | head -1 || echo "")
+
+          if [ -z "$COPILOT_PR" ]; then
+            echo "No copilot/* PR found targeting automated/upstream-sync. No merge-back needed."
+            echo "copilot_merged=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Found Copilot adaptation PR #${COPILOT_PR}. Merging into automated/upstream-sync..."
+
+          # Get the head ref name
+          COPILOT_BRANCH=$(gh pr view "$COPILOT_PR" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json headRefName \
+            --jq '.headRefName' 2>/dev/null || echo "")
+
+          if [ -n "$COPILOT_BRANCH" ]; then
+            git fetch origin "$COPILOT_BRANCH" 2>/dev/null || true
+            git merge "origin/$COPILOT_BRANCH" --no-edit --allow-unrelated-histories 2>/dev/null || true
+
+            # Close the copilot/* PR since we merged it directly
+            gh pr close "$COPILOT_PR" \
+              --repo "$GITHUB_REPOSITORY" \
+              --comment "Merged into automated/upstream-sync directly by upstream-sync workflow." \
+              || true
+
+            echo "copilot_merged=true" >> "$GITHUB_OUTPUT"
+            echo "Copilot adaptation branch merged successfully."
+          else
+            echo "::warning::Could not determine copilot branch name for PR #${COPILOT_PR}."
+            echo "copilot_merged=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run prompt generator
+        if: steps.detect.outputs.no_changes != 'true' && steps.merge.outcome == 'success'
+        run: |
+          node scripts/generate-prompts.mjs > /tmp/gen_output.txt 2>&1
+          echo "Generator output:"
+          cat /tmp/gen_output.txt
+
+      - name: Run prompt verifier
+        if: steps.detect.outputs.no_changes != 'true' && steps.merge.outcome == 'success'
+        id: verify
+        run: |
+          if ! node scripts/verify-prompts.mjs > /tmp/ver_output.txt 2>&1; then
+            cat > /tmp/issue-body.md << 'ISSUE_EOF'
+          ## Upstream Sync Verifier Failure
+
+          The upstream sync completed merge and regeneration, but the verifier failed. No PR was created.
+
+          **Upstream commit:** ${{ steps.detect.outputs.short_sha }}
+          **Upstream HEAD:** ${{ steps.detect.outputs.upstream_head }}
+
+          ### Generator output
+          ```
+          ISSUE_EOF
+            cat /tmp/gen_output.txt >> /tmp/issue-body.md
+            cat >> /tmp/issue-body.md << 'ISSUE_EOF'
+          ```
+
+          ### Verifier output
+          ```
+          ISSUE_EOF
+            cat /tmp/ver_output.txt >> /tmp/issue-body.md
+            cat >> /tmp/issue-body.md << 'ISSUE_EOF'
+          ```
+
+          ### Resolution steps
+          1. Review the verifier errors above
+          2. Fix `scripts/generate-prompts.mjs` or `scripts/verify-prompts.mjs` as needed (do NOT edit upstream content)
+          3. Re-run workflow or fix and push manually
+
+          **Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ISSUE_EOF
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Upstream sync verifier failed (upstream@${{ steps.detect.outputs.short_sha }})" \
+              --body-file /tmp/issue-body.md \
+              --label "upstream-sync"
+            exit 1
+          fi
+          echo "Verifier passed."
+          cat /tmp/ver_output.txt
+
+      - name: Commit regenerated wrapper files
+        if: steps.detect.outputs.no_changes != 'true' && steps.merge.outcome == 'success'
+        run: |
+          git add --all .github/prompts/ 2>/dev/null || true
+          git add --all .github/agents/ 2>/dev/null || true
+          git add --all .github/instructions/ 2>/dev/null || true
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: regenerate Copilot wrapper layer for upstream@${{ steps.detect.outputs.short_sha }}"
+          else
+            echo "No wrapper file changes to commit."
+          fi
+
+      # SYNC-03: Close any open PRs for automated/upstream-sync before force-pushing so the
+      # replacement PR always reflects the current branch state cleanly.
+      - name: Close superseded sync PRs
+        if: steps.detect.outputs.no_changes != 'true' && steps.merge.outcome == 'success'
+        run: |
+          OPEN_PRS=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "automated/upstream-sync" \
+            --state open \
+            --json number \
+            --jq '.[].number' 2>/dev/null || echo "")
+
+          for PR_NUM in $OPEN_PRS; do
+            gh pr comment "$PR_NUM" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body "Closing — superseded by a new upstream sync run (upstream@${{ steps.detect.outputs.short_sha }}). A fresh PR will be created for this run."
+            gh pr close "$PR_NUM" \
+              --repo "$GITHUB_REPOSITORY"
+            echo "Closed stale PR #${PR_NUM}."
+          done
+
+      - name: Force-push working branch
+        if: steps.detect.outputs.no_changes != 'true' && steps.merge.outcome == 'success'
+        run: |
+          git push --force-with-lease origin automated/upstream-sync
+
+      - name: Check open escalations
+        if: steps.detect.outputs.no_changes != 'true' && steps.merge.outcome == 'success'
+        id: check_escalations
+        run: |
+          OPEN_COUNT=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label "escalation" \
+            --state open \
+            --json number \
+            --jq 'length' 2>/dev/null || echo "0")
+
+          if [ "$OPEN_COUNT" -gt 0 ]; then
+            echo "has_escalation=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::${OPEN_COUNT} open escalation issue(s) found. Auto-merge will be blocked on this sync."
+          else
+            echo "has_escalation=false" >> "$GITHUB_OUTPUT"
+            echo "No open escalation issues."
+          fi
+
+      - name: Build PR body
+        if: steps.detect.outputs.no_changes != 'true' && steps.merge.outcome == 'success'
+        run: |
+          NOTIFY="${{ vars.NOTIFY_MAINTAINER }}"
+          # Default: tag the user unless NOTIFY_MAINTAINER explicitly set to "false"
+          TAG_LINE=""
+          TAG_NOTE=""
+          if [ "${NOTIFY:-true}" != "false" ]; then
+            TAG_LINE="cc @dwisner — substantive adaptations were made autonomously."
+            TAG_NOTE="To disable maintainer tagging, set repository variable \`NOTIFY_MAINTAINER\` to \`false\` at: Settings → Secrets and variables → Actions → Variables tab."
+          fi
+
+          # Read runtime files (truncate to avoid 65k body limit)
+          DELTA_ANALYSIS=$(cat /tmp/delta-analysis.md 2>/dev/null | head -c 3000 || echo "(not available)")
+          ADAPTATIONS=$(cat /tmp/adaptations-summary.md 2>/dev/null | head -c 2000 || echo "(proactive adaptation step did not run or made no changes)")
+          RANGE="${{ steps.detect.outputs.fork_head }}...${{ steps.detect.outputs.upstream_head }}"
+
+          # Determine coverage gaps section
+          HAS_NEW_COMMANDS="${{ steps.analyze_delta.outputs.has_new_commands }}"
+          if [ "${HAS_NEW_COMMANDS}" = "true" ]; then
+            GAPS_SECTION="New upstream commands/agents were detected. The proactive adaptation agent was instructed to create wrapper prompts. See Fork adaptations section for details."
+          else
+            GAPS_SECTION="No new upstream commands or agents detected."
+          fi
+
+          # Determine security section for open issues
+          SECURITY_FLAGGED="${{ steps.analyze_delta.outputs.security_flagged }}"
+          OPEN_ISSUES_SECTION=""
+          if [ "${SECURITY_FLAGGED}" = "true" ]; then
+            OPEN_ISSUES_SECTION="⚠️ **Security-sensitive upstream YAML changes detected.** Auto-merge was blocked. Review the delta analysis above before merging."
+          fi
+
+          cat > /tmp/pr-body.md << PR_EOF
+          ## Upstream sync from \`gsd-build/get-shit-done\`
+
+          **Upstream commit:** \`${{ steps.detect.outputs.short_sha }}\`
+          **Commit range:** \`${RANGE}\`
+
+          ---
+
+          ### 📥 Upstream changes
+
+          ${DELTA_ANALYSIS}
+
+          ---
+
+          ### 🔧 Fork adaptations
+
+          ${ADAPTATIONS}
+
+          ---
+
+          ### 🆕 Coverage gaps filled
+
+          ${GAPS_SECTION}
+
+          ---
+
+          ### ✅ No action needed
+
+          Generator and verifier passed. Wrapper layer regenerated automatically.
+
+          ---
+
+          ### 🚨 Open issues
+
+          ${OPEN_ISSUES_SECTION:-"None detected on this run."}
+
+          ---
+
+          ${TAG_LINE}
+          ${TAG_NOTE}
+
+          *This PR was created automatically. [Workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})*
+          PR_EOF
+
+      # SYNC-01/02: Create (or update) the PR and immediately enable auto-merge so it lands on
+      # main without manual intervention as soon as required checks pass.
+      # Prerequisite: Settings → General → Pull Requests → "Allow auto-merge" must be ON.
+      - name: Create or update PR
+        if: steps.detect.outputs.no_changes != 'true' && steps.merge.outcome == 'success'
+        id: create_pr
+        run: |
+          SHORT_SHA="${{ steps.detect.outputs.short_sha }}"
+          PR_TITLE="sync: upstream changes from ${SHORT_SHA}"
+
+          # After the close-stale step, there should be no open PR, but guard defensively.
+          EXISTING_PR=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "automated/upstream-sync" \
+            --state open \
+            --json number \
+            --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -z "$EXISTING_PR" ]; then
+            PR_URL=$(gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base "${{ env.DEFAULT_BRANCH }}" \
+              --head "automated/upstream-sync" \
+              --title "${PR_TITLE}" \
+              --body-file /tmp/pr-body.md \
+              --label "upstream-sync" \
+              --label "automated")
+            echo "Created new PR: ${PR_URL}"
+            PR_NUMBER=$(basename "$PR_URL")
+            echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          else
+            gh pr edit "$EXISTING_PR" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "${PR_TITLE}" \
+              --body-file /tmp/pr-body.md
+            echo "Updated existing PR #${EXISTING_PR}."
+            echo "pr_number=${EXISTING_PR}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # SYNC-01/02: Enable auto-merge on the PR (merge commit strategy preserves upstream commit SHAs
+      # in main's ancestry, which is required for GitHub's 'X commits behind upstream' indicator to
+      # clear correctly after merge. Squash would create a new SHA and main would always appear behind.)
+      # This is a no-op when auto-merge is already enabled; safe to run on every sync.
+      - name: Enable auto-merge on sync PR
+        if: >
+          steps.detect.outputs.no_changes != 'true' &&
+          steps.merge.outcome == 'success' &&
+          steps.create_pr.outputs.pr_number != '' &&
+          steps.check_escalations.outputs.has_escalation != 'true' &&
+          steps.analyze_delta.outputs.security_flagged != 'true'
+        run: |
+          gh pr merge "${{ steps.create_pr.outputs.pr_number }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --auto \
+            --merge
+          echo "Auto-merge enabled on PR #${{ steps.create_pr.outputs.pr_number }}."
+
+  repair:
+    name: Self-Repair (Copilot Agent)
+    runs-on: ubuntu-latest
+    needs: sync
+    if: always() && needs.sync.result != 'skipped'
+    timeout-minutes: 90
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.COPILOT_PAT }}
+
+    steps:
+      # SAFETY: Always run this assertion first. Add --repo "$GITHUB_REPOSITORY" to any new gh command you add here.
+      - name: Assert fork context
+        run: |
+          if [ "$GITHUB_REPOSITORY" != "${{ env.EXPECTED_REPO }}" ]; then
+            echo "ERROR: This workflow is running on '$GITHUB_REPOSITORY' but is only intended to run on '${{ env.EXPECTED_REPO }}'."
+            echo "Refusing to proceed — this prevents accidental writes to the wrong repository."
+            exit 1
+          fi
+
+      - name: Check COPILOT_PAT
+        id: preflight
+        run: |
+          if [ -z "${{ secrets.COPILOT_PAT }}" ]; then
+            echo "::warning::COPILOT_PAT secret is not set. Skipping self-repair job."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.preflight.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.COPILOT_PAT }}
+
+      - name: Setup Node
+        if: steps.preflight.outputs.skip != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Configure git identity
+        if: steps.preflight.outputs.skip != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch upstream
+        if: steps.preflight.outputs.skip != 'true'
+        run: |
+          git remote add upstream https://github.com/gsd-build/get-shit-done.git 2>/dev/null || true
+          git fetch upstream
+
+      - name: Validate agent-task auth
+        if: steps.preflight.outputs.skip != 'true'
+        id: agent_auth
+        run: |
+          # The Copilot coding agent is triggered by creating a GitHub issue
+          # assigned to 'copilot'. This requires a classic OAuth PAT (ghp_...)
+          # with 'repo' scope — no codespace scope, no interactive login needed.
+          #
+          # IMPORTANT: gh agent-task create is NOT used. Despite having a valid
+          # ghp_... PAT with all required scopes stored in the credential store,
+          # gh agent-task still fails with "this command requires an OAuth token"
+          # because it internally requires a token obtained via the OAuth
+          # device/browser flow — which is impossible in CI. This is a gh CLI
+          # design constraint with no workaround.
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::COPILOT_PAT secret is not set. Cannot invoke Copilot coding agent."
+            echo "agent_auth_ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if echo "${GH_TOKEN:-}" | grep -q '^github_pat_'; then
+            echo "::error::COPILOT_PAT is a fine-grained token (github_pat_...). The Copilot issue-assignment trigger requires a classic OAuth PAT (ghp_...) with 'repo' scope. Regenerate at github.com/settings/tokens."
+            echo "agent_auth_ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! echo "${GH_TOKEN:-}" | grep -q '^ghp_'; then
+            echo "::error::COPILOT_PAT does not appear to be a classic OAuth PAT (expected ghp_... prefix). Regenerate at github.com/settings/tokens."
+            echo "agent_auth_ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # ghp_... prefix is sufficient to confirm this is a classic OAuth PAT.
+          # Scope validation via 'gh auth status' is NOT used here: when GH_TOKEN
+          # is set as an env var (as it is in this job), gh reports 'Token scopes: none'
+          # because scope metadata is only stored when using 'gh auth login'.
+          # If the token lacks 'repo' scope, 'gh issue create' will fail with a
+          # clear API error at the point of use.
+          echo "COPILOT_PAT is a valid classic OAuth PAT. Ready for issue-based Copilot agent invocation."
+          echo "agent_auth_ok=true" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve merge conflict via Copilot agent
+        if: steps.preflight.outputs.skip != 'true' && needs.sync.outputs.merge_conflict == 'true'
+        id: conflict_resolve
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_PAT }}
+        run: |
+          set -euo pipefail
+
+          # Emit safe defaults first so outputs are always defined even on early exit.
+          echo "conflict_resolved=false" >> "$GITHUB_OUTPUT"
+          echo "conflict_dead_end=false" >> "$GITHUB_OUTPUT"
+
+          CONFLICT_FILES="${{ needs.sync.outputs.merge_conflict_files }}"
+          UPSTREAM_SHA="${{ needs.sync.outputs.short_sha || 'unknown' }}"
+
+          echo "Attempting agent-assisted merge conflict resolution for: ${CONFLICT_FILES}"
+
+          # Re-establish the conflict state on the working branch
+          git checkout -B automated/upstream-sync origin/${{ env.DEFAULT_BRANCH }} 2>/dev/null || true
+          git merge "upstream/${{ env.UPSTREAM_BRANCH }}" --no-edit 2>/dev/null || true
+
+          # Capture the conflict diff (truncated to 15k)
+          CONFLICT_DIFF=$(git diff --diff-filter=U 2>/dev/null | head -c 15000 || echo "(conflict diff unavailable)")
+
+          cat > /tmp/conflict-resolve-prompt.md << PROMPT_EOF
+          You are the GSD upstream-sync merge conflict resolution agent.
+
+          A merge conflict occurred between the fork's main branch and upstream/main.
+          The following files have conflicts that could not be auto-resolved:
+
+          **Conflicting files:** ${CONFLICT_FILES}
+          **Upstream SHA:** ${UPSTREAM_SHA}
+
+          ## Your mission
+
+          Resolve the merge conflict to produce a clean, committable state.
+
+          ## Authority — what you MAY modify
+          - Any conflicting file listed above (to resolve the conflict)
+          - scripts/generate-prompts.mjs (if needed to handle upstream changes)
+          - scripts/verify-prompts.mjs (if needed)
+          - .github/prompts/**
+          - .github/agents/**
+          - .github/instructions/**
+          - README.md, FORK-CHANGELOG.md, AGENTS.md
+
+          ## Hard limit — NEVER modify
+          - commands/gsd/**
+          - agents/**
+          - get-shit-done/**
+
+          ## Fork identity rules for conflict resolution
+          - In fork-owned files (package.json, README.md, FORK-CHANGELOG.md, AGENTS.md):
+            the fork's content takes precedence. Accept upstream changes only where they
+            don't conflict with the fork's identity (e.g., accept upstream version bumps
+            to dependency fields, but keep fork-specific description/repository fields).
+          - CHANGELOG.md is upstream-owned: accept --theirs (the fork maintains FORK-CHANGELOG.md separately).
+          - In any other upstream-owned content that somehow drifted: accept --theirs.
+
+          ## Required steps
+          1. Resolve all conflicts in the listed files.
+          2. Run: git add -A && git commit -m "chore: resolve merge conflict with upstream/${UPSTREAM_SHA}"
+          3. Run: node scripts/generate-prompts.mjs
+          4. Run: node scripts/verify-prompts.mjs
+          5. Both must pass.
+          6. Open a PR from the copilot/* branch you created in this task targeting base: automated/upstream-sync (NOT main).
+          7. PR title: "sync: upstream changes (conflict resolved by agent)"
+          8. If the conflict cannot be resolved autonomously, write "DEAD_END" to /tmp/repair-dead-end.txt and stop.
+
+          ## Conflict diff
+          \`\`\`diff
+          ${CONFLICT_DIFF}
+          \`\`\`
+          PROMPT_EOF
+
+          # Trigger Copilot coding agent via issue assignment.
+          # gh agent-task create cannot be used in CI — it requires an interactive
+          # Trigger Copilot coding agent via issue assignment.
+          # Issue is created first (no assignee) to guarantee the issue exists
+          # and the prompt is captured even if Copilot assignment fails.
+          echo "Creating Copilot conflict-resolution issue..."
+          CONFLICT_ISSUE_URL=$(gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "fix(upstream-sync): resolve merge conflict [${{ needs.sync.outputs.short_sha || 'unknown' }}]" \
+            --body-file /tmp/conflict-resolve-prompt.md \
+            --label "upstream-sync" \
+            2>&1) || true
+          echo "gh issue create output: $CONFLICT_ISSUE_URL"
+          CONFLICT_ISSUE=$(echo "$CONFLICT_ISSUE_URL" | grep -oP '/issues/\K[0-9]+' || echo "")
+          [[ "$CONFLICT_ISSUE" =~ ^[0-9]+$ ]] || CONFLICT_ISSUE=""
+
+          if [ -n "$CONFLICT_ISSUE" ]; then
+            echo "Assigning Copilot coding agent to issue #${CONFLICT_ISSUE}..."
+            ASSIGN_OUT=$(gh issue edit "$CONFLICT_ISSUE" \
+              --repo "$GITHUB_REPOSITORY" \
+              --add-assignee "Copilot" \
+              2>&1) || true
+            echo "gh issue edit (assignee) output: $ASSIGN_OUT"
+            CONFLICT_ISSUE_CREATED_AT=$(gh issue view "$CONFLICT_ISSUE" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json createdAt \
+              --jq '.createdAt' 2>/dev/null || echo "")
+
+            if [ -z "$CONFLICT_ISSUE_CREATED_AT" ]; then
+              echo "::warning::Failed to retrieve creation time for issue #${CONFLICT_ISSUE}. Proceeding without PR association filter."
+            fi
+
+            echo "Created issue #${CONFLICT_ISSUE}. Waiting up to 20 minutes for Copilot to open a PR..."
+            POLL_MAX=24
+            POLL_COUNT=0
+            AGENT_PR=""
+            while [ $POLL_COUNT -lt $POLL_MAX ]; do
+              if [ -n "$CONFLICT_ISSUE_CREATED_AT" ]; then
+                export CONFLICT_ISSUE_CREATED_AT
+                AGENT_PR=$(gh pr list \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --base "automated/upstream-sync" \
+                  --state open \
+                  --json number,headRefName,createdAt \
+                  --jq '.[] | select((.headRefName | startswith("copilot/")) and (.createdAt >= env.CONFLICT_ISSUE_CREATED_AT)) | .number' \
+                  2>/dev/null | head -1 || echo "")
+              else
+                AGENT_PR=$(gh pr list \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --base "automated/upstream-sync" \
+                  --state open \
+                  --json number,headRefName \
+                  --jq '.[] | select(.headRefName | startswith("copilot/")) | .number' \
+                  2>/dev/null | head -1 || echo "")
+              fi
+              if [ -n "$AGENT_PR" ]; then
+                echo "Copilot PR #${AGENT_PR} found after ~$((POLL_COUNT * 50))s."
+                break
+              fi
+              sleep 50
+              POLL_COUNT=$((POLL_COUNT + 1))
+            done
+            if [ -n "$AGENT_PR" ]; then
+              gh issue close "$CONFLICT_ISSUE" \
+                --repo "$GITHUB_REPOSITORY" \
+                --comment "Processed by upstream-sync conflict resolution step." \
+                2>/dev/null || true
+            else
+              echo "::warning::Copilot coding agent did not open a PR within 20 minutes. Leaving issue #${CONFLICT_ISSUE} open."
+            fi
+          else
+            echo "::warning::Failed to create conflict resolution issue."
+          fi
+
+          # Check if agent resolved conflicts (dead-end sentinel)
+          if [ -f /tmp/repair-dead-end.txt ]; then
+            echo "Agent declared DEAD_END on conflict resolution."
+            echo "conflict_dead_end=true" >> "$GITHUB_OUTPUT"
+          else
+            # Agent creates a copilot/* branch PR targeting automated/upstream-sync.
+            # Check for that PR's existence as the success signal — do NOT check local
+            # git state, which still reflects the unresolved merge from this runner.
+            AGENT_PR=$(gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --base "automated/upstream-sync" \
+              --state open \
+              --json number,headRefName \
+              --jq '.[] | select(.headRefName | startswith("copilot/")) | .number' \
+              2>/dev/null | head -1 || echo "")
+            if [ -n "$AGENT_PR" ]; then
+              echo "Agent created PR #${AGENT_PR} — conflict resolution submitted."
+              echo "conflict_resolved=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "Agent did not create a PR and no DEAD_END sentinel found — treating as unresolved."
+            fi
+          fi
+
+      - name: Repair loop
+        if: steps.preflight.outputs.skip != 'true' && needs.sync.outputs.merge_conflict != 'true'
+        id: repair_loop
+        run: |
+          set -euo pipefail
+
+          # Switch to the working branch that the sync job produced.
+          # The checkout step lands on main; the repair agent must operate on
+          # automated/upstream-sync so the verifier sees the sync-merged content
+          # and all merges/pushes go to the correct branch.
+          git fetch origin automated/upstream-sync ${{ env.DEFAULT_BRANCH }} 2>/dev/null || true
+          git checkout -B automated/upstream-sync origin/automated/upstream-sync 2>/dev/null || \
+            git checkout -B automated/upstream-sync origin/${{ env.DEFAULT_BRANCH }} 2>/dev/null || true
+
+          # If main is ahead of automated/upstream-sync (e.g. a prior repair PR was
+          # merged into main but automated/upstream-sync still points at an older commit),
+          # reset to main. Without this, the generator creates files that are already in
+          # main and git diff shows nothing new — so no commit is made and
+          # gh pr create fails with "no commits between main and automated/upstream-sync".
+          COMMITS_BEHIND=$(git rev-list HEAD..origin/${{ env.DEFAULT_BRANCH }} --count 2>/dev/null || echo "0")
+          if [ "$COMMITS_BEHIND" -gt 0 ]; then
+            echo "automated/upstream-sync is ${COMMITS_BEHIND} commit(s) behind ${{ env.DEFAULT_BRANCH }} — resetting to ${{ env.DEFAULT_BRANCH }} as new base."
+            git reset --hard origin/${{ env.DEFAULT_BRANCH }}
+          fi
+
+          # Run initial verify to see if repair is needed.
+          # Do this BEFORE the auth gate: if the verifier passes there is nothing
+          # for the agent to do and a bad/missing auth token is irrelevant.
+          if node scripts/verify-prompts.mjs 2>&1 | tee /tmp/verify_initial.log; then
+            echo "Verifier passed — no repair needed."
+            echo "repair_needed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          REPAIR_NEEDED=true
+          CURRENT_ERRORS=$(cat /tmp/verify_initial.log | head -c 5000)
+
+          # Record the branch state NOW — before any self-heal commit or agent work.
+          # The guard step uses this as the diff baseline to see only what this job
+          # changed, rather than diffing the entire branch vs upstream/main (which
+          # would flag legitimately-merged upstream files as violations).
+          PRE_REPAIR_SHA=$(git rev-parse HEAD)
+          echo "$PRE_REPAIR_SHA" > /tmp/pre-repair-sha
+          echo "pre_repair_sha=${PRE_REPAIR_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Pre-repair SHA: ${PRE_REPAIR_SHA}"
+
+          # ── Self-heal pass ──────────────────────────────────────────────────────
+          # Most failures are simply stale generated prompts. Re-running the
+          # generator and committing is enough — no agent needed.
+          echo "Running generator self-heal pass..."
+          if node scripts/generate-prompts.mjs 2>&1 | tee /tmp/gen_selfheal.log; then
+            if node scripts/verify-prompts.mjs 2>&1 | tee /tmp/verify_selfheal.log; then
+              echo "Self-heal succeeded — generator fixed the verifier errors."
+              echo "--- git status before add ---"
+              git status --short .github/prompts/ scripts/ || true
+              # Use --all to ensure new (untracked) files are included, not just modifications.
+              # Split into one call per directory — if a directory doesn't exist git add
+              # fails the entire multi-path invocation, staging nothing.
+              git add --all .github/prompts/ 2>/dev/null || true
+              git add --all .github/agents/ 2>/dev/null || true
+              git add --all .github/instructions/ 2>/dev/null || true
+              git add --all scripts/ 2>/dev/null || true
+              echo "--- git diff --cached after add ---"
+              git diff --cached --stat || true
+              if ! git diff --cached --quiet; then
+                git commit -m "chore(upstream-sync): regenerate prompts after upstream merge"
+                git push origin HEAD:automated/upstream-sync --force-with-lease
+              else
+                echo "::warning::Generator ran and verifier passed, but no files were staged. The generated output may already match origin/main."
+              fi
+              # Ensure a PR exists to merge automated/upstream-sync → main.
+              # The sync job creates the PR when no verifier errors exist at sync time;
+              # when repair is needed the sync job does NOT create a PR, so we must.
+              EXISTING_PR=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+                --head "automated/upstream-sync" --json number --jq '.[0].number' 2>/dev/null || echo "")
+              if [ -z "$EXISTING_PR" ]; then
+                echo "No existing PR for automated/upstream-sync — creating one..."
+                PR_CREATE_EXIT=0
+                CREATED_PR_URL=$(gh pr create \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --base main \
+                  --head "automated/upstream-sync" \
+                  --title "sync: upstream changes (self-heal)" \
+                  --body "Automated upstream sync. Verifier errors were resolved by the self-heal pass (generator re-run)." \
+                  --label "upstream-sync" \
+                  --label "automated" 2>&1) || PR_CREATE_EXIT=$?
+                echo "gh pr create output: $CREATED_PR_URL"
+                SYNC_PR_NUMBER=$(echo "$CREATED_PR_URL" | grep -oP '/pull/\K[0-9]+' || echo "")
+                if [ "$PR_CREATE_EXIT" -ne 0 ] && [ -z "$SYNC_PR_NUMBER" ]; then
+                  echo "::warning::gh pr create failed (exit $PR_CREATE_EXIT) and no open PR could be resolved for automated/upstream-sync. Auto-merge will be skipped."
+                fi
+              else
+                echo "PR #${EXISTING_PR} already exists for automated/upstream-sync."
+                SYNC_PR_NUMBER="$EXISTING_PR"
+              fi
+              # Enable auto-merge so the PR lands once all required checks pass.
+              # Prerequisite: Settings → General → Pull Requests → "Allow auto-merge" must be ON.
+              # If this warning fires, enable that setting in the repo and re-run.
+              if [ -n "$SYNC_PR_NUMBER" ]; then
+                gh pr merge "$SYNC_PR_NUMBER" \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --auto \
+                  --merge 2>&1 || echo "::warning::Failed to enable auto-merge on PR #${SYNC_PR_NUMBER}. Enable 'Allow auto-merge' in Settings → General → Pull Requests, then re-run."
+              fi
+              echo "repair_needed=true" >> "$GITHUB_OUTPUT"
+              echo "repair_succeeded=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            else
+              echo "Generator ran but verifier still fails — agent repair needed."
+              CURRENT_ERRORS=$(cat /tmp/verify_selfheal.log | head -c 5000)
+            fi
+          else
+            echo "Generator itself failed — agent repair needed."
+          fi
+          # ────────────────────────────────────────────────────────────────────────
+
+          # Verifier failed — we need the agent. Now check auth.
+          if [ "${{ steps.agent_auth.outputs.agent_auth_ok }}" = "false" ]; then
+            echo "::error::Repair needed but COPILOT_PAT auth failed. See 'Validate agent-task auth' step. Verifier errors:"
+            cat /tmp/verify_initial.log
+            echo "dead_end=true" >> "$GITHUB_OUTPUT"
+            echo "repair_needed=true" >> "$GITHUB_OUTPUT"
+            echo "repair_succeeded=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          STRATEGIES=("basic_verifier_fix" "contextual_generative_fix" "full_rewrite" "alt_approach")
+          STRATEGY_IDX=0
+          REPAIR_NEEDED=false
+          REPAIR_SUCCEEDED=false
+          DEAD_END=false
+
+          # Gather diagnostic context once
+          # UPSTREAM_DIFF is the primary context source — re-derived here because /tmp/delta-analysis.md
+          # from the sync job is NOT available cross-job (different runner). The git diff provides equivalent context.
+          UPSTREAM_DIFF=$(git diff HEAD upstream/main -- . \
+            ':(exclude)commands/gsd' ':(exclude)get-shit-done' ':(exclude)agents' \
+            2>/dev/null | head -c 20000 || true)
+          GENERATOR_SRC=$(cat scripts/generate-prompts.mjs 2>/dev/null || echo "(unavailable)")
+          VERIFIER_SRC=$(cat scripts/verify-prompts.mjs 2>/dev/null || echo "(unavailable)")
+          # Expected to fall back to "(delta analysis unavailable)" in the repair job — UPSTREAM_DIFF above is the primary source.
+          DELTA_ANALYSIS=$(cat /tmp/delta-analysis.md 2>/dev/null || echo "(delta analysis unavailable — different runner; see UPSTREAM_DIFF above)")
+
+          build_repair_prompt() {
+            local strategy=$1
+            local attempt=$2
+            local current_errors=$3
+
+            # Collect prior patches for context
+            local prior_patches=""
+            for i in $(seq 1 $((attempt - 1))); do
+              if [ -f "/tmp/patch_attempt_${i}.diff" ]; then
+                prior_patches="${prior_patches}"$'\n\n'"## Failed Patch — Attempt ${i} (strategy: ${STRATEGIES[$((i-1))]})"
+                prior_patches="${prior_patches}"$'\n'"$(cat /tmp/patch_attempt_${i}.diff | head -c 4000)"
+              fi
+            done
+
+            # Strategy-specific framing
+            local framing=""
+            case "$strategy" in
+              basic_verifier_fix)
+                framing="Focus on the exact verifier error messages. Make the smallest targeted fix that makes verify-prompts.mjs pass."
+                ;;
+              contextual_generative_fix)
+                framing="Prior targeted fix(es) did not work. Now consider the full upstream delta context. What structural change in upstream caused this? Fix generate-prompts.mjs or verify-prompts.mjs to handle the new upstream pattern."
+                ;;
+              full_rewrite)
+                framing="Prior fixes failed. Rewrite the failing section(s) of generate-prompts.mjs and/or verify-prompts.mjs from scratch. Ignore prior patches — take a clean approach. You may rewrite the entire file if needed."
+                ;;
+              alt_approach)
+                framing="All prior strategies failed. Try a completely different architectural approach. Consider whether a different data structure, parsing strategy, or output format would resolve the issue. Be creative."
+                ;;
+            esac
+
+            cat <<PROMPT
+          You are the GSD upstream-sync repair agent. Attempt ${attempt}, strategy: ${strategy}.
+
+          ${framing}
+
+          ## Authority — what you MAY modify
+          - scripts/generate-prompts.mjs
+          - scripts/verify-prompts.mjs
+          - scripts/tools.json
+          - .github/workflows/upstream-sync.yml
+          - .github/prompts/**
+          - .github/agents/**
+          - .github/instructions/**
+          - README.md
+          - FORK-CHANGELOG.md
+          - AGENTS.md
+
+          ## Hard limit — NEVER modify
+          - commands/gsd/**
+          - agents/**
+          - get-shit-done/**
+
+          ## Required steps
+          1. Fix the issue.
+          2. Run: node scripts/generate-prompts.mjs && node scripts/verify-prompts.mjs
+          3. Both must pass.
+          4. Open a PR targeting branch: automated/upstream-sync
+          5. Write a descriptive commit message explaining what you changed and why.
+          6. If you determine the problem requires human input or cannot be solved autonomously, write "DEAD_END" to /tmp/repair-dead-end.txt and stop immediately.
+
+          ## Current Verifier Errors
+          \`\`\`
+          ${current_errors}
+          \`\`\`
+
+          ## Upstream Delta Analysis
+          ${DELTA_ANALYSIS}
+
+          ## Upstream Diff (truncated to 20k chars)
+          \`\`\`diff
+          ${UPSTREAM_DIFF}
+          \`\`\`
+
+          ## scripts/generate-prompts.mjs (current)
+          \`\`\`js
+          ${GENERATOR_SRC}
+          \`\`\`
+
+          ## scripts/verify-prompts.mjs (current)
+          \`\`\`js
+          ${VERIFIER_SRC}
+          \`\`\`
+          ${prior_patches}
+          PROMPT
+          }
+
+          # Strategy-pool loop
+          while [ "$STRATEGY_IDX" -lt "${#STRATEGIES[@]}" ]; do
+            STRATEGY="${STRATEGIES[$STRATEGY_IDX]}"
+            ATTEMPT=$((STRATEGY_IDX + 1))
+            STRATEGY_IDX=$((STRATEGY_IDX + 1))
+
+            echo "::group::Repair attempt ${ATTEMPT} — strategy: ${STRATEGY}"
+
+            # Write prompt to file (avoids shell escaping issues)
+            build_repair_prompt "$STRATEGY" "$ATTEMPT" "$CURRENT_ERRORS" > /tmp/repair_prompt_${ATTEMPT}.txt
+
+            # Snapshot branch state before agent runs (for no-diff dead-end detection)
+            PRE_AGENT_SHA=$(git rev-parse HEAD 2>/dev/null || echo "")
+
+            # Trigger Copilot coding agent via issue assignment.
+            # IMPORTANT: gh agent-task create is intentionally NOT used.
+            # gh agent-task requires a token from the OAuth device/browser flow —
+            # it internally checks the token's origin, not just its scopes. A ghp_...
+            # PAT with every required scope (codespace, repo, workflow) stored in
+            # the gh credential store is still rejected with "this command requires
+            # an OAuth token". This is a gh CLI design constraint with no workaround.
+            # Issue is created first (no assignee) to guarantee the issue exists
+            # and the prompt is captured even if Copilot assignment fails.
+            COPILOT_PR=""
+            REPAIR_ISSUE_URL=$(gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "repair(upstream-sync): fix verifier [attempt ${ATTEMPT}, ${STRATEGY}]" \
+              --body-file /tmp/repair_prompt_${ATTEMPT}.txt \
+              --label "upstream-sync" \
+              2>&1) || true
+            echo "gh issue create output: $REPAIR_ISSUE_URL"
+            REPAIR_ISSUE=$(echo "$REPAIR_ISSUE_URL" | grep -oP '/issues/\K[0-9]+' || echo "")
+            [[ "$REPAIR_ISSUE" =~ ^[0-9]+$ ]] || REPAIR_ISSUE=""
+
+            if [ -z "$REPAIR_ISSUE" ]; then
+              echo "::warning::Failed to create Copilot repair issue (see output above)."
+              echo "::endgroup::"
+              continue
+            fi
+
+            echo "Assigning Copilot coding agent to issue #${REPAIR_ISSUE}..."
+            ASSIGN_OUT=$(gh issue edit "$REPAIR_ISSUE" \
+              --repo "$GITHUB_REPOSITORY" \
+              --add-assignee "Copilot" \
+              2>&1) || true
+            echo "gh issue edit (assignee) output: $ASSIGN_OUT"
+
+            REPAIR_ISSUE_CREATED_AT=$(gh issue view "$REPAIR_ISSUE" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json createdAt \
+              --jq '.createdAt' 2>/dev/null || echo "")
+
+            if [ -z "$REPAIR_ISSUE_CREATED_AT" ]; then
+              echo "::warning::Failed to retrieve creation time for issue #${REPAIR_ISSUE}. Proceeding without PR association filter."
+            fi
+
+            echo "Created issue #${REPAIR_ISSUE}. Waiting up to 20 minutes for Copilot coding agent to open a PR..."
+            POLL_MAX=24
+            POLL_COUNT=0
+            while [ $POLL_COUNT -lt $POLL_MAX ]; do
+              if [ -n "$REPAIR_ISSUE_CREATED_AT" ]; then
+                export REPAIR_ISSUE_CREATED_AT
+                COPILOT_PR=$(gh pr list \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --base "automated/upstream-sync" \
+                  --state open \
+                  --json number,headRefName,createdAt \
+                  --jq '.[] | select((.headRefName | startswith("copilot/")) and (.createdAt >= env.REPAIR_ISSUE_CREATED_AT)) | .number' \
+                  2>/dev/null | head -1 || echo "")
+              else
+                COPILOT_PR=$(gh pr list \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --base "automated/upstream-sync" \
+                  --state open \
+                  --json number,headRefName \
+                  --jq '.[] | select(.headRefName | startswith("copilot/")) | .number' \
+                  2>/dev/null | head -1 || echo "")
+              fi
+              if [ -n "$COPILOT_PR" ]; then
+                echo "Copilot PR #${COPILOT_PR} found after ~$((POLL_COUNT * 50))s."
+                break
+              fi
+              sleep 50
+              POLL_COUNT=$((POLL_COUNT + 1))
+            done
+
+            if [ -n "$COPILOT_PR" ]; then
+              gh issue close "$REPAIR_ISSUE" \
+                --repo "$GITHUB_REPOSITORY" \
+                --comment "Processed by upstream-sync repair loop (attempt ${ATTEMPT}, strategy: ${STRATEGY})." \
+                2>/dev/null || true
+            else
+              echo "::warning::Copilot coding agent did not open a PR within 20 minutes on strategy ${STRATEGY}. Leaving issue #${REPAIR_ISSUE} open."
+            fi
+
+            if [ -n "$COPILOT_PR" ]; then
+              COPILOT_BRANCH=$(gh pr view "$COPILOT_PR" \
+                --repo "$GITHUB_REPOSITORY" \
+                --json headRefName \
+                --jq '.headRefName' 2>/dev/null || echo "")
+              if [ -n "$COPILOT_BRANCH" ]; then
+                git fetch origin "$COPILOT_BRANCH" 2>/dev/null || true
+                git merge "origin/$COPILOT_BRANCH" --no-edit --allow-unrelated-histories 2>/dev/null || true
+                gh pr close "$COPILOT_PR" \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --comment "Merged into automated/upstream-sync by repair loop (attempt ${ATTEMPT}, strategy: ${STRATEGY})." \
+                  || true
+              fi
+            else
+              # Pull any direct commits from agent
+              git pull origin automated/upstream-sync --rebase 2>/dev/null || true
+            fi
+
+            # Capture what the agent did
+            git diff "$PRE_AGENT_SHA" HEAD > /tmp/patch_attempt_${ATTEMPT}.diff 2>/dev/null || true
+
+            # Dead-end sentinel check
+            if [ -f /tmp/repair-dead-end.txt ]; then
+              DEAD_END=true
+              echo "::warning::Agent wrote DEAD_END sentinel on strategy ${STRATEGY}. Escalating."
+              echo "::endgroup::"
+              break
+            fi
+
+            # No-diff dead-end: agent ran but made no changes AND verifier still fails
+            if [ ! -s /tmp/patch_attempt_${ATTEMPT}.diff ]; then
+              echo "::warning::Agent made no changes on strategy ${STRATEGY}."
+              # Don't immediately dead-end — try next strategy
+            fi
+
+            # Re-run verifier
+            if node scripts/verify-prompts.mjs > /tmp/verify_attempt_${ATTEMPT}.log 2>&1; then
+              echo "Verifier passed on attempt ${ATTEMPT} (strategy: ${STRATEGY})."
+              REPAIR_SUCCEEDED=true
+
+              # Push the repaired branch
+              git push origin HEAD:automated/upstream-sync --force-with-lease
+
+              # Create or update the PR (if it doesn't already exist from the sync job's normal flow)
+              EXISTING_PR=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+                --head "automated/upstream-sync" --json number --jq '.[0].number' 2>/dev/null || echo "")
+              if [ -z "$EXISTING_PR" ]; then
+                PR_CREATE_EXIT=0
+                CREATED_PR_URL=$(gh pr create \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --base main \
+                  --head "automated/upstream-sync" \
+                  --title "sync: upstream changes (autonomous repair)" \
+                  --body-file /tmp/pr-body.md \
+                  --label "upstream-sync" \
+                  --label "automated" 2>&1) || PR_CREATE_EXIT=$?
+                echo "gh pr create output: $CREATED_PR_URL"
+                SYNC_PR_NUMBER=$(echo "$CREATED_PR_URL" | grep -oP '/pull/\K[0-9]+' || echo "")
+                if [ "$PR_CREATE_EXIT" -ne 0 ] && [ -z "$SYNC_PR_NUMBER" ]; then
+                  echo "::warning::gh pr create failed (exit $PR_CREATE_EXIT) and no open PR could be resolved for automated/upstream-sync. Auto-merge will be skipped."
+                fi
+              else
+                SYNC_PR_NUMBER="$EXISTING_PR"
+              fi
+              if [ -n "$SYNC_PR_NUMBER" ]; then
+                gh pr merge "$SYNC_PR_NUMBER" \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --auto \
+                  --merge 2>&1 || echo "::warning::Failed to enable auto-merge on PR #${SYNC_PR_NUMBER}. Enable 'Allow auto-merge' in Settings → General → Pull Requests, then re-run."
+              fi
+
+              echo "repair_succeeded=true" >> "$GITHUB_OUTPUT"
+              echo "repair_needed=true" >> "$GITHUB_OUTPUT"
+              echo "::endgroup::"
+              break
+            fi
+
+            echo "::warning::Verifier failed after attempt ${ATTEMPT} (strategy: ${STRATEGY})."
+            CURRENT_ERRORS=$(cat /tmp/verify_attempt_${ATTEMPT}.log | head -c 5000)
+            echo "::endgroup::"
+          done
+
+          # Write final outputs
+          echo "repair_needed=true" >> "$GITHUB_OUTPUT"
+          if [ "$DEAD_END" = "true" ]; then
+            echo "dead_end=true" >> "$GITHUB_OUTPUT"
+            echo "repair_succeeded=false" >> "$GITHUB_OUTPUT"
+          elif [ "$REPAIR_SUCCEEDED" = "false" ]; then
+            echo "attempts_exhausted=true" >> "$GITHUB_OUTPUT"
+            echo "repair_succeeded=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Write repair summary to step summary
+          echo "## Repair Loop Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "Strategies tried: ${STRATEGY_IDX} of ${#STRATEGIES[@]}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Repair succeeded: ${REPAIR_SUCCEEDED}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Dead end: ${DEAD_END}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Filesystem guard (post-repair)
+        if: steps.preflight.outputs.skip != 'true' && steps.repair_loop.outputs.repair_needed == 'true'
+        env:
+          PRE_REPAIR_BASELINE: ${{ steps.repair_loop.outputs.pre_repair_sha }}
+        run: |
+          bash scripts/guard-upstream-files.sh post-commit
+
+      - name: Escalate — Create GitHub issue
+        if: >
+          (needs.sync.result == 'failure' && needs.sync.outputs.merge_conflict != 'true') ||
+          steps.repair_loop.outputs.attempts_exhausted == 'true' ||
+          steps.repair_loop.outputs.dead_end == 'true' ||
+          steps.conflict_resolve.outputs.conflict_dead_end == 'true' ||
+          needs.sync.outputs.security_flagged == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_PAT }}
+        run: |
+          set -euo pipefail
+
+          NOTIFY="${{ vars.NOTIFY_MAINTAINER }}"
+          USER_TAG=""
+          if [ "${NOTIFY:-true}" != "false" ]; then
+            USER_TAG="@dwisner — manual intervention required."
+          fi
+
+          # Determine trigger type for stable title
+          TRIGGER_TYPE="strategies-exhausted"
+          if [ "${{ steps.repair_loop.outputs.dead_end }}" = "true" ]; then
+            TRIGGER_TYPE="dead-end-sentinel"
+          elif [ "${{ steps.conflict_resolve.outputs.conflict_dead_end }}" = "true" ]; then
+            TRIGGER_TYPE="merge-conflict-unresolvable"
+          fi
+
+          ISSUE_TITLE="sync-escalation: autonomous maintenance dead-end"
+
+          # Deduplication: check for existing open escalation issue
+          EXISTING_ISSUE=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label "escalation" \
+            --state open \
+            --search '"sync-escalation: autonomous maintenance dead-end" in:title' \
+            --json number \
+            --jq '.[0].number' 2>/dev/null || echo "")
+
+          # Diagnostic content (truncated to stay well under 65k limit)
+          VERIFY_LOG=$(cat /tmp/verify_attempt_4.log 2>/dev/null | head -c 3000 || \
+                       cat /tmp/verify_attempt_3.log 2>/dev/null | head -c 3000 || \
+                       cat /tmp/verify_initial.log 2>/dev/null | head -c 3000 || echo "(none)")
+          UPSTREAM_DIFF_EXCERPT=$(git diff HEAD upstream/main -- . \
+            ':(exclude)commands/gsd' ':(exclude)get-shit-done' ':(exclude)agents' \
+            2>/dev/null | head -c 8000 || echo "(none)")
+
+          # Build escalation body
+          cat > /tmp/escalation-body.md << ESC_EOF
+          ## Escalation: ${TRIGGER_TYPE}
+
+          The autonomous upstream-sync repair agent reached a dead-end on this run.
+
+          **Trigger:** ${TRIGGER_TYPE}
+          **Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          ${USER_TAG}
+
+          ### Verifier Output (last attempt)
+          \`\`\`
+          ${VERIFY_LOG}
+          \`\`\`
+
+          ### Upstream Diff (excerpt)
+          \`\`\`diff
+          ${UPSTREAM_DIFF_EXCERPT}
+          \`\`\`
+          ESC_EOF
+
+          # --- Channel 1: GitHub Issue (create or comment on existing) ---
+          if [ -n "$EXISTING_ISSUE" ] && [ "$EXISTING_ISSUE" != "null" ]; then
+            echo "Open escalation issue #${EXISTING_ISSUE} already exists. Adding comment."
+            gh issue comment "$EXISTING_ISSUE" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body-file /tmp/escalation-body.md
+            ISSUE_REF="$EXISTING_ISSUE"
+          else
+            echo "Creating new escalation issue..."
+            # Ensure the label exists (idempotent — never fails if already present)
+            gh label create "escalation" \
+              --color "d93f0b" \
+              --description "Escalation required: autonomous maintenance dead-end" \
+              --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+
+            # Create issue without label flag (so creation never fails due to missing label)
+            NEW_ISSUE_URL=$(gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "${ISSUE_TITLE}" \
+              --body-file /tmp/escalation-body.md)
+            ISSUE_REF=$(basename "$NEW_ISSUE_URL")
+
+            # Apply label separately — failure here is non-fatal
+            gh issue edit "$ISSUE_REF" \
+              --repo "$GITHUB_REPOSITORY" \
+              --add-label "escalation" 2>/dev/null || true
+
+            echo "Created escalation issue #${ISSUE_REF}."
+          fi
+
+          # --- Channel 2: Comment on open sync PR (if one exists) ---
+          OPEN_PR=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "automated/upstream-sync" \
+            --state open \
+            --json number \
+            --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -n "$OPEN_PR" ] && [ "$OPEN_PR" != "null" ]; then
+            echo "Posting escalation comment on sync PR #${OPEN_PR}..."
+            PR_COMMENT="🚨 **Escalation triggered:** \`${TRIGGER_TYPE}\`. See issue #${ISSUE_REF} for details. ${USER_TAG}"
+            gh pr comment "$OPEN_PR" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body "$PR_COMMENT"
+            echo "Comment posted on sync PR #${OPEN_PR}."
+          else
+            echo "No open sync PR found. Skipping PR comment (issue created above)."
+          fi
+
+  guard:
+    # SAFETY: Always run the 'Assert fork context' step first. Add --repo "$GITHUB_REPOSITORY" to any new gh command you add here.
+    name: Filesystem Guard (copilot/* branches)
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/heads/copilot/')
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      # SAFETY: Always run this assertion first. Add --repo "$GITHUB_REPOSITORY" to any new gh command you add here.
+      - name: Assert fork context
+        run: |
+          if [ "$GITHUB_REPOSITORY" != "${{ env.EXPECTED_REPO }}" ]; then
+            echo "ERROR: This workflow is running on '$GITHUB_REPOSITORY' but is only intended to run on '${{ env.EXPECTED_REPO }}'."
+            echo "Refusing to proceed — this prevents accidental writes to the wrong repository."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch upstream
+        run: |
+          git remote add upstream https://github.com/gsd-build/get-shit-done.git 2>/dev/null || true
+          git fetch upstream
+
+      - name: Run filesystem guard
+        run: |
+          bash scripts/guard-upstream-files.sh post-commit
+
+  release-mirror:
+    name: Release Mirror
+    runs-on: ubuntu-latest
+    # Must wait for repair: if repair is regenerating prompts and creating a PR,
+    # we don't want the release mirror to run against an inconsistent branch state.
+    needs: [sync, repair]
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.COPILOT_PAT }}
+
+    steps:
+      # SAFETY: Always run this assertion first. Add --repo "$GITHUB_REPOSITORY" to any new gh command you add here.
+      - name: Assert fork context
+        run: |
+          if [ "$GITHUB_REPOSITORY" != "${{ env.EXPECTED_REPO }}" ]; then
+            echo "ERROR: This workflow is running on '$GITHUB_REPOSITORY' but is only intended to run on '${{ env.EXPECTED_REPO }}'."
+            echo "Refusing to proceed — this prevents accidental writes to the wrong repository."
+            exit 1
+          fi
+
+      - name: Check COPILOT_PAT
+        id: preflight
+        run: |
+          if [ -z "${{ secrets.COPILOT_PAT }}" ]; then
+            echo "::warning::COPILOT_PAT secret is not set. Skipping release-mirror job."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect upstream release
+        if: steps.preflight.outputs.skip != 'true'
+        id: detect_release
+        run: |
+          UPSTREAM_REPO="${{ env.UPSTREAM_REPO }}"
+
+          UPSTREAM_TAG=$(gh api "repos/${UPSTREAM_REPO}/releases/latest" \
+            --jq '.tag_name' 2>/dev/null || echo "")
+
+          if [ -z "$UPSTREAM_TAG" ] || [ "$UPSTREAM_TAG" = "null" ]; then
+            echo "No upstream release found. Exiting silently."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "upstream_tag=${UPSTREAM_TAG}" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "Upstream latest release: ${UPSTREAM_TAG}"
+
+      - name: Check if already mirrored
+        if: steps.preflight.outputs.skip != 'true' && steps.detect_release.outputs.skip != 'true'
+        id: check_mirror
+        run: |
+          UPSTREAM_TAG="${{ steps.detect_release.outputs.upstream_tag }}"
+
+          MIRRORED=$(gh release list \
+            --repo "$GITHUB_REPOSITORY" \
+            --limit 100 \
+            --json tagName \
+            --jq "[.[] | select(.tagName | contains(\"upstream-${UPSTREAM_TAG}\"))] | length" \
+            2>/dev/null || echo "0")
+
+          if [ "$MIRRORED" -gt 0 ]; then
+            echo "Already mirrored upstream release ${UPSTREAM_TAG}. Exiting silently."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "New upstream release detected: ${UPSTREAM_TAG}"
+
+      # REL-06: Validate that the fork is no more than 1 release behind upstream.
+      # Runs regardless of whether the current upstream tag is already mirrored.
+      # A gap of 0 (fully current) or 1 (mirror job will handle it this run) is normal and silent.
+      # A gap > 1 means the mirror job has been failing silently — alert the maintainer.
+      - name: Lockstep validation
+        if: steps.preflight.outputs.skip != 'true' && steps.detect_release.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          UPSTREAM_REPO="${{ env.UPSTREAM_REPO }}"
+          REPO_OWNER="${GITHUB_REPOSITORY%%/*}"
+
+          # Get the last 10 upstream release tag names (newest first)
+          UPSTREAM_TAGS=$(gh api "repos/${UPSTREAM_REPO}/releases?per_page=10" \
+            --jq '[.[].tag_name]' 2>/dev/null || echo "[]")
+
+          # Get fork's latest release tag
+          FORK_LATEST=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" \
+            --jq '.tag_name // empty' 2>/dev/null || echo "")
+
+          if [ -z "$FORK_LATEST" ] || [ "$FORK_LATEST" = "null" ]; then
+            # No fork releases yet — gap = total upstream count in our window
+            GAP=$(echo "$UPSTREAM_TAGS" | jq 'length')
+          else
+            # Extract the embedded upstream tag: "v0.0.3-upstream-v2.1.0" → "v2.1.0"
+            EMBEDDED=$(echo "$FORK_LATEST" | sed 's/.*-upstream-//' || echo "")
+
+            if [ -z "$EMBEDDED" ]; then
+              # Fork latest release is not a mirror release — treat as unknown gap
+              GAP=99
+            else
+              # Find position (0-indexed) of embedded tag in upstream releases list
+              # Position 0 = fully current, 1 = one behind (this run will fix it), >1 = alert
+              POSITION=$(echo "$UPSTREAM_TAGS" | jq --arg tag "$EMBEDDED" 'index($tag) // 99')
+              GAP=$POSITION
+            fi
+          fi
+
+          echo "Release lockstep gap: ${GAP} (fork is ${GAP} upstream release(s) behind)"
+
+          if [ "$GAP" -le 1 ]; then
+            echo "Gap is acceptable (≤1). No alert needed."
+            exit 0
+          fi
+
+          # Gap > 1: create or update a deduplicating alert issue
+          ISSUE_TITLE="[upstream-mirror] Release lockstep gap"
+          UPSTREAM_LATEST="${{ steps.detect_release.outputs.upstream_tag }}"
+
+          EXISTING=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --search "is:issue is:open \"${ISSUE_TITLE}\" in:title" \
+            --json number \
+            --jq '.[0].number' 2>/dev/null || echo "")
+
+          cat > /tmp/lockstep-body.md << BODY_EOF
+          ## Release lockstep gap detected
+
+          The fork is **${GAP}** upstream release(s) behind. The release-mirror job should keep this gap at ≤1 on each run. A persistent gap suggests the mirror job has been failing silently.
+
+          | Field | Value |
+          |---|---|
+          | Upstream latest release | \`${UPSTREAM_LATEST}\` |
+          | Fork latest release | \`${FORK_LATEST:-"(none)"}\` |
+          | Gap | ${GAP} release(s) |
+          | Workflow run | [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
+
+          ### Resolution
+          1. Check the release-mirror job logs for the failing run.
+          2. If the release-mirror job completed successfully this run, the gap will reduce to 0 automatically.
+          3. Close this issue once the fork's latest release mirrors the upstream latest.
+          BODY_EOF
+
+          if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
+            gh issue comment "$EXISTING" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body-file /tmp/lockstep-body.md
+            echo "::warning::Lockstep gap=${GAP}. Updated existing issue #${EXISTING}."
+          else
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "${ISSUE_TITLE}" \
+              --label "upstream-mirror" \
+              --label "bug" \
+              ${REPO_OWNER:+--assignee "$REPO_OWNER"} \
+              --body-file /tmp/lockstep-body.md
+            echo "::warning::Lockstep gap=${GAP}. Created new alert issue."
+          fi
+
+      # Gate step: consolidates all skip signals into a single `proceed` output.
+      # A skipped step emits empty-string outputs; 'someStep.outputs.x != true' is TRUE for empty string,
+      # which would cause all downstream write-steps to fire incorrectly if gated only on check_mirror.
+      # Using == 'true' here means the gate itself being skipped (empty proceed) naturally blocks downstream.
+      - name: Gate — proceed only if release is new
+        if: steps.preflight.outputs.skip != 'true' && steps.detect_release.outputs.skip != 'true' && steps.check_mirror.outputs.skip != 'true'
+        id: gate
+        run: |
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+          echo "All guards passed — proceeding with tag push and release mirroring."
+
+      - name: Compute fork tag
+        if: steps.gate.outputs.proceed == 'true'
+        id: compute_tag
+        run: |
+          UPSTREAM_TAG="${{ steps.detect_release.outputs.upstream_tag }}"
+
+          FORK_LATEST=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" \
+            --jq '.tag_name' 2>/dev/null || echo "")
+
+          if [ -z "$FORK_LATEST" ] || [ "$FORK_LATEST" = "null" ]; then
+            FORK_PATCH=0
+          else
+            BASE_VER="${FORK_LATEST%%-*}"     # "v0.0.3-upstream-v2.1.0" → "v0.0.3"
+            FORK_PATCH="${BASE_VER##*.}"       # "v0.0.3" → "3"
+          fi
+
+          NEXT_PATCH=$((FORK_PATCH + 1))
+          NEW_TAG="v0.0.${NEXT_PATCH}-upstream-${UPSTREAM_TAG}"
+
+          echo "new_tag=${NEW_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Computed new fork tag: ${NEW_TAG}"
+
+      - name: Checkout fork for tag push
+        if: steps.gate.outputs.proceed == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.COPILOT_PAT }}
+
+      - name: Configure git identity
+        if: steps.gate.outputs.proceed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Push fork tag via COPILOT_PAT
+        # COPILOT_PAT REQUIRED: GITHUB_TOKEN tag pushes do NOT trigger downstream workflows.
+        # release.yml fires on push:tags:v* — this ONLY works if the tag is pushed via a PAT.
+        if: steps.gate.outputs.proceed == 'true'
+        id: push_tag
+        run: |
+          git remote set-url origin "https://x-access-token:${{ secrets.COPILOT_PAT }}@github.com/${{ github.repository }}.git"
+          NEW_TAG="${{ steps.compute_tag.outputs.new_tag }}"
+          UPSTREAM_TAG="${{ steps.detect_release.outputs.upstream_tag }}"
+
+          git tag -a "$NEW_TAG" -m "Mirror upstream release ${UPSTREAM_TAG}"
+          git push origin "$NEW_TAG"
+
+          echo "Pushed tag: ${NEW_TAG}"
+
+      - name: Poll for release.yml to create release
+        if: steps.gate.outputs.proceed == 'true'
+        id: poll_release
+        run: |
+          NEW_TAG="${{ steps.compute_tag.outputs.new_tag }}"
+          CREATED=false
+
+          echo "Polling for release creation by release.yml (max 5 min: 20 × 15s)..."
+          for i in $(seq 1 20); do
+            RELEASE_ID=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/${NEW_TAG}" \
+              --jq '.id // empty' 2>/dev/null || echo "")
+            # Guard: gh api writes error JSON to stdout on non-200 responses;
+            # reject anything that is not a bare integer (e.g. JSON 404 payloads).
+            [[ "$RELEASE_ID" =~ ^[0-9]+$ ]] || RELEASE_ID=""
+            if [ -n "$RELEASE_ID" ]; then
+              echo "Release created (id=${RELEASE_ID}) after attempt ${i}."
+              CREATED=true
+              echo "created=true" >> "$GITHUB_OUTPUT"
+              echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+              break
+            fi
+            echo "  Waiting... attempt ${i}/20"
+            sleep 15
+          done
+
+          if [ "$CREATED" = "false" ]; then
+            echo "::warning::release.yml did not create release within 5 minutes. Will create directly."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build release body
+        if: steps.gate.outputs.proceed == 'true'
+        run: |
+          NEW_TAG="${{ steps.compute_tag.outputs.new_tag }}"
+          UPSTREAM_TAG="${{ steps.detect_release.outputs.upstream_tag }}"
+          UPSTREAM_REPO="${{ env.UPSTREAM_REPO }}"
+
+          UPSTREAM_BODY=$(gh api "repos/${UPSTREAM_REPO}/releases/latest" \
+            --jq '.body' 2>/dev/null || echo "")
+
+          # Guard: jq returns literal string "null" for JSON null fields (P2)
+          if [ -z "$UPSTREAM_BODY" ] || [ "$UPSTREAM_BODY" = "null" ]; then
+            UPSTREAM_BODY="_Upstream release notes unavailable._"
+          fi
+
+          # Quoted heredoc for static fork header — prevents expansion of any $ in fork-controlled text (P3)
+          cat > /tmp/release-body.md << 'HEADER_EOF'
+          ## Fork Mirror: __NEW_TAG__
+
+          | Field | Value |
+          |---|---|
+          | Fork tag | `__NEW_TAG__` |
+          | Upstream release | `__UPSTREAM_TAG__` |
+          | Upstream release URL | __UPSTREAM_URL__ |
+          | Sync status | ✅ Merged via upstream-sync |
+
+          ---
+
+          ## Upstream Release Notes (__UPSTREAM_TAG__)
+
+          HEADER_EOF
+
+          sed -i \
+            -e "s|__NEW_TAG__|${NEW_TAG}|g" \
+            -e "s|__UPSTREAM_TAG__|${UPSTREAM_TAG}|g" \
+            -e "s|__UPSTREAM_URL__|https://github.com/${UPSTREAM_REPO}/releases/tag/${UPSTREAM_TAG}|g" \
+            /tmp/release-body.md
+
+          # Append upstream body OUTSIDE heredoc to safely pass through $, backticks, etc. (P3)
+          printf '%s\n' "$UPSTREAM_BODY" >> /tmp/release-body.md
+
+      - name: Inject release body or create release directly
+        if: steps.gate.outputs.proceed == 'true'
+        run: |
+          NEW_TAG="${{ steps.compute_tag.outputs.new_tag }}"
+
+          if [ "${{ steps.poll_release.outputs.created }}" = "true" ]; then
+            # release.yml already created the release — overwrite auto-generated notes
+            # Use release ID (not tag name) to avoid 'release not found' from gh release edit's by-tag lookup
+            RELEASE_ID="${{ steps.poll_release.outputs.release_id }}"
+            # Sanity-check: must be a numeric ID — fail loudly rather than corrupt the API call
+            if [[ ! "$RELEASE_ID" =~ ^[0-9]+$ ]]; then
+              echo "::error::RELEASE_ID '$RELEASE_ID' is not a valid numeric ID. Aborting release body patch."
+              exit 1
+            fi
+            jq -n --rawfile body /tmp/release-body.md '{"body": $body}' > /tmp/release-patch.json
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/${RELEASE_ID}" \
+              --input /tmp/release-patch.json
+            echo "Release body updated via gh api PATCH (id=${RELEASE_ID})."
+          else
+            # Fallback: release.yml timed out; create release directly with full body
+            gh release create "$NEW_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "GSD Copilot ${NEW_TAG}" \
+              --notes-file /tmp/release-body.md
+            echo "Release created directly (fallback path)."
+          fi
+
+      - name: Handle failure — create or update GitHub issue
+        if: failure() && steps.preflight.outputs.skip != 'true'
+        run: |
+          UPSTREAM_TAG="${{ steps.detect_release.outputs.upstream_tag }}"
+          NEW_TAG="${{ steps.compute_tag.outputs.new_tag }}"
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          REPO_OWNER=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.owner.login' 2>/dev/null || echo "")
+          RECENT_LOG=$(git log --oneline -5 2>/dev/null || echo "(unavailable)")
+
+          # Stable title — run number must NOT appear here or dedup search will never match a prior issue
+          ISSUE_TITLE="[upstream-mirror] Release mirror failure"
+
+          # Verbose diagnostic body written to file — never --body with inline multi-line string
+          cat > /tmp/failure-detail.md << BODY_EOF
+          ## upstream-mirror Failure — Run #${{ github.run_number }}
+
+          | Field | Value |
+          |---|---|
+          | Workflow run | [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
+          | Timestamp | ${TIMESTAMP} |
+          | Upstream tag checked | ${UPSTREAM_TAG:-"(not yet resolved)"} |
+          | Fork tag at failure | ${NEW_TAG:-"(not yet computed)"} |
+
+          ### Recent git log (last 5 commits)
+          \`\`\`
+          ${RECENT_LOG}
+          \`\`\`
+
+          ### Environment (secrets redacted)
+          - GITHUB_REPOSITORY: \`$GITHUB_REPOSITORY\`
+          - GITHUB_REF: \`$GITHUB_REF\`
+          - EXPECTED_REPO: \`${{ env.EXPECTED_REPO }}\`
+          BODY_EOF
+
+          # Deduplication: comment on existing open issue rather than create a duplicate
+          EXISTING=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --search "is:issue is:open \"${ISSUE_TITLE}\" in:title" \
+            --json number \
+            --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
+            gh issue comment "$EXISTING" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body-file /tmp/failure-detail.md
+            echo "Commented on existing issue #${EXISTING}."
+          else
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "${ISSUE_TITLE}" \
+              --label "bug" \
+              --label "upstream-mirror" \
+              ${REPO_OWNER:+--assignee "$REPO_OWNER"} \
+              --body-file /tmp/failure-detail.md
+            echo "Created new issue."
+          fi
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# GSD → Copilot Port Maintainer (Fork)
+
+## Goal
+Keep this fork synced with upstream gsd-build/get-shit-done while maintaining a Copilot compatibility layer.
+
+## Golden rule
+Do NOT rewrite upstream content. Upstream directories remain source-of-truth:
+- commands/gsd/**
+- get-shit-done/workflows/**
+- agents/**
+Only maintain the Copilot wrapper layer:
+- .github/prompts/**  (VS Code slash commands)
+- .github/agents/**   (custom Copilot agents)
+- .github/copilot-instructions.md
+- .github/instructions/**
+
+## Sync PR workflow (what to do when @copilot is pinged)
+1) Identify upstream changes.
+2) Run: `node scripts/generate-prompts.mjs`
+3) Run: `node scripts/verify-prompts.mjs`
+4) Commit regenerated wrapper files.
+5) If generator/verification fails due to upstream changes, fix the generator/verification scripts (do not rewrite upstream docs).
+
+## Naming conventions
+- Prompt command names use dot-namespace: /gsd.new-project
+- Mapping is stable: gsd:<cmd> → gsd.<cmd>
+
+## Automated Sync Workflow
+
+The upstream sync is now **automated via GitHub Actions** (`upstream-sync.yml`):
+
+> **Sync direction: downstream only.**
+> The `gsd-upstream-sync` agent syncs changes FROM `gsd-build/get-shit-done` INTO this fork — it does not push commits or open PRs on the upstream repo. There is no automated path to do so, by design.
+>
+> If asked to contribute changes back to `gsd-build/get-shit-done`, decline and instruct the user to do so manually by opening a PR on the upstream repo directly.
+
+### Daily Schedule
+1. **Detection:** Compares fork HEAD with `upstream/main`
+2. **Merge:** `git merge upstream/main` (if changes exist)
+3. **Generation:** `node scripts/generate-prompts.mjs`
+4. **Verification:** `node scripts/verify-prompts.mjs`
+5. **PR Creation:** Submits PR on **this fork** if validation passes
+
+### If Validation Fails
+When generator or verifier fails:
+1. **Sync Agent Invoked:** `@gsd-upstream-sync` agent analyzes the problem
+2. **Diagnosis:** Agent reads failing scripts and upstream changes
+3. **Fix:** Agent updates generator/verifier scripts (never upstream content)
+4. **Verification:** Agent re-runs scripts to confirm fix works
+5. **Commit:** Changes committed and PR created on this fork
+
+See `.github/instructions/upstream-sync-guide.md` for full details and manual sync options.
+
+## Definition of Done
+- [ ] PR contains upstream merge + updated Copilot wrapper layer
+- [ ] Generator + verification scripts pass
+- [ ] No manual edits to upstream files unless absolutely unavoidable and explained
+- [ ] If upstream changes broke generator/verifier, sync agent fixed them
+- [ ] All generated prompts validated

--- a/FORK-CHANGELOG.md
+++ b/FORK-CHANGELOG.md
@@ -1,0 +1,21 @@
+# Fork Changelog
+
+All fork-specific changes to `get-shit-done-github-copilot` are documented here.  
+This file covers **v1.5 and later**. For v1.0–v1.4 history, see [CHANGELOG.md](CHANGELOG.md).
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).  
+This fork tracks the upstream [gsd-build/get-shit-done](https://github.com/gsd-build/get-shit-done) release cadence and layers a VS Code Copilot compatibility shim on top.
+
+---
+
+## [v1.5] - 2026-02-22 — Repo Metadata Alignment
+
+### Added
+- `FORK-CHANGELOG.md` — fork-specific release history (this file), forward-looking from v1.5
+- Fork identity documentation phase (Phase 16): rewrote README for VS Code Copilot audience, added AGENTS.md and CLAUDE.md, documented fork vs upstream relationship, recorded fork-specific CHANGELOG history through v1.4
+
+### Changed
+- `package.json`: updated `description` and `repository.url` to reflect this fork (not upstream)
+- `.github/FUNDING.yml`: added comment explaining intentional decision to retain upstream funding link
+- `.github/ISSUE_TEMPLATE/bug_report.yml`: replaced upstream-specific fields (npm version check, runtime dropdown) with fork-appropriate AI assistant input field
+- `README.md`: removed broken Option A install method (degit `.github`-only copy); removed incorrect "no Node.js required" claims; installation section now directs users to PowerShell installer or release zip

--- a/README.md
+++ b/README.md
@@ -1,207 +1,124 @@
 <div align="center">
 
-# GET SHIT DONE
+# GET SHIT DONE — VS Code GitHub Copilot Port
 
-**A light-weight and powerful meta-prompting, context engineering and spec-driven development system for Claude Code, OpenCode, Gemini CLI, and Codex.**
+**A VS Code GitHub Copilot compatibility layer for the [Get Shit Done (GSD)](https://github.com/gsd-build/get-shit-done) spec-driven development system.**
 
-**Solves context rot — the quality degradation that happens as Claude fills its context window.**
-
-[![npm version](https://img.shields.io/npm/v/get-shit-done-cc?style=for-the-badge&logo=npm&logoColor=white&color=CB3837)](https://www.npmjs.com/package/get-shit-done-cc)
-[![npm downloads](https://img.shields.io/npm/dm/get-shit-done-cc?style=for-the-badge&logo=npm&logoColor=white&color=CB3837)](https://www.npmjs.com/package/get-shit-done-cc)
-[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/5JJgD5svVS)
-[![X (Twitter)](https://img.shields.io/badge/X-@gsd__foundation-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/gsd_foundation)
-[![$GSD Token](https://img.shields.io/badge/$GSD-Dexscreener-1C1C1C?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSIxMCIgZmlsbD0iIzAwRkYwMCIvPjwvc3ZnPg==&logoColor=00FF00)](https://dexscreener.com/solana/dwudwjvan7bzkw9zwlbyv6kspdlvhwzrqy6ebk8xzxkv)
-[![GitHub stars](https://img.shields.io/github/stars/glittercowboy/get-shit-done?style=for-the-badge&logo=github&color=181717)](https://github.com/glittercowboy/get-shit-done)
+[![GitHub stars](https://img.shields.io/github/stars/gsd-build/get-shit-done?style=for-the-badge&logo=github&color=181717)](https://github.com/gsd-build/get-shit-done)
 [![License](https://img.shields.io/badge/license-MIT-blue?style=for-the-badge)](LICENSE)
-
-<br>
-
-```bash
-npx get-shit-done-cc@latest
-```
-
-**Works on Mac, Windows, and Linux.**
-
-<br>
-
-![GSD Install](assets/terminal.svg)
-
-<br>
-
-*"If you know clearly what you want, this WILL build it for you. No bs."*
-
-*"I've done SpecKit, OpenSpec and Taskmaster — this has produced the best results for me."*
-
-*"By far the most powerful addition to my Claude Code. Nothing over-engineered. Literally just gets shit done."*
-
-<br>
-
-**Trusted by engineers at Amazon, Google, Shopify, and Webflow.**
-
-[Why I Built This](#why-i-built-this) · [How It Works](#how-it-works) · [Commands](#commands) · [Why It Works](#why-it-works) · [User Guide](docs/USER-GUIDE.md)
 
 </div>
 
 ---
 
-## Why I Built This
-
-I'm a solo developer. I don't write code — Claude Code does.
-
-Other spec-driven development tools exist; BMAD, Speckit... But they all seem to make things way more complicated than they need to be (sprint ceremonies, story points, stakeholder syncs, retrospectives, Jira workflows) or lack real big picture understanding of what you're building. I'm not a 50-person software company. I don't want to play enterprise theater. I'm just a creative person trying to build great things that work.
-
-So I built GSD. The complexity is in the system, not in your workflow. Behind the scenes: context engineering, XML prompt formatting, subagent orchestration, state management. What you see: a few commands that just work.
-
-The system gives Claude everything it needs to do the work *and* verify it. I trust the workflow. It just does a good job.
-
-That's what this is. No enterprise roleplay bullshit. Just an incredibly effective system for building cool stuff consistently using Claude Code.
-
-— **TÂCHES**
+> **This is a fork, not the upstream project.**
+> If you use **Claude Code**, **OpenCode**, or **Gemini CLI**, install GSD directly from upstream: [gsd-build/get-shit-done](https://github.com/gsd-build/get-shit-done).
+> This fork is for **VS Code GitHub Copilot** users only.
 
 ---
 
-Vibecoding has a bad reputation. You describe what you want, AI generates code, and you get inconsistent garbage that falls apart at scale.
+## What This Fork Is
 
-GSD fixes that. It's the context engineering layer that makes Claude Code reliable. Describe your idea, let the system extract everything it needs to know, and let Claude Code get to work.
+This repository is a VS Code GitHub Copilot port of the [Get Shit Done (GSD)](https://github.com/gsd-build/get-shit-done) project management system, originally built for Claude Code by TÂCHES / glittercowboy.
+
+It exposes the full GSD command set as VS Code Copilot Chat slash commands (`/gsd.new-project`, `/gsd.execute-phase`, etc.) and adds a sync pipeline that automatically pulls upstream changes and regenerates the Copilot wrapper layer.
+
+**This fork adds:**
+- VS Code Copilot prompt layer (`.github/prompts/gsd.*.prompt.md`)
+- Tool mapping from GSD XML task format to Copilot tool calls
+- PowerShell installer
+- Daily upstream sync pipeline with auto-regeneration
+
+**Core GSD methodology, workflow engine, templates, and agents are upstream's work.** See [Credits & Attribution](#credits--attribution).
 
 ---
 
-## Who This Is For
+## Who This Fork Is For
 
-People who want to describe what they want and have it built correctly — without pretending they're running a 50-person engineering org.
+VS Code GitHub Copilot users who want to use GSD's spec-driven development workflow through Copilot Chat slash commands.
+
+**Use upstream instead** ([gsd-build/get-shit-done](https://github.com/gsd-build/get-shit-done)) if you are following Claude Code, OpenCode, or Gemini CLI installation instructions  those runtimes are natively supported upstream and this fork adds nothing for them.
 
 ---
 
-## Getting Started
+## Install
 
-```bash
-npx get-shit-done-cc@latest
+### PowerShell Installer (recommended)
+
+Open a PowerShell terminal in your project root:
+
+```powershell
+irm "https://raw.githubusercontent.com/maitaitime/get-shit-done-github-copilot/main/gsd-copilot-installer/gsd-copilot-install.ps1" | iex
 ```
 
-The installer prompts you to choose:
-1. **Runtime** — Claude Code, OpenCode, Gemini, Codex, or all
-2. **Location** — Global (all projects) or local (current project only)
+For full installer options, arguments, and troubleshooting, see [gsd-copilot-installer/README.md](gsd-copilot-installer/README.md).
 
-Verify with:
-- Claude Code / Gemini: `/gsd:help`
-- OpenCode: `/gsd-help`
-- Codex: `$gsd-help`
+---
 
-> [!NOTE]
-> Codex installation uses skills (`skills/gsd-*/SKILL.md`) rather than custom prompts.
+## Getting Started with VS Code Copilot
 
-### Staying Updated
+1. **Install** using the option above.
+2. **Open** VS Code Copilot Chat (`` Ctrl+Shift+I `` or the chat icon).
+3. **Verify** the commands are available  type `/gsd` and you should see the command list in the slash command picker.
+4. **Initialize your project:**
 
-GSD evolves fast. Update periodically:
+   ```
+   /gsd.new-project
+   ```
 
-```bash
-npx get-shit-done-cc@latest
-```
+   The command guides you through questions  research  requirements  roadmap.
 
-<details>
-<summary><strong>Non-interactive Install (Docker, CI, Scripts)</strong></summary>
+5. **Plan and execute:**
 
-```bash
-# Claude Code
-npx get-shit-done-cc --claude --global   # Install to ~/.claude/
-npx get-shit-done-cc --claude --local    # Install to ./.claude/
+   ```
+   /gsd.discuss-phase 1
+   /gsd.plan-phase 1
+   /gsd.execute-phase 1
+   /gsd.verify-work 1
+   ```
 
-# OpenCode (open source, free models)
-npx get-shit-done-cc --opencode --global # Install to ~/.config/opencode/
+6. **Check progress anytime:**
 
-# Gemini CLI
-npx get-shit-done-cc --gemini --global   # Install to ~/.gemini/
+   ```
+   /gsd.progress
+   /gsd.help
+   ```
 
-# Codex (skills-first)
-npx get-shit-done-cc --codex --global    # Install to ~/.codex/
-npx get-shit-done-cc --codex --local     # Install to ./.codex/
+> **Already have code?** Run `/gsd.map-codebase` first to analyze your stack, then `/gsd.new-project` knows your codebase.
 
-# All runtimes
-npx get-shit-done-cc --all --global      # Install to all directories
-```
+---
 
-Use `--global` (`-g`) or `--local` (`-l`) to skip the location prompt.
-Use `--claude`, `--opencode`, `--gemini`, `--codex`, or `--all` to skip the runtime prompt.
+## Credits & Attribution
 
-</details>
+This fork would not exist without the original **Get Shit Done** project by **TÂCHES / glittercowboy**.
 
-<details>
-<summary><strong>Development Installation</strong></summary>
+| Resource | Link |
+|----------|------|
+| Upstream repo | [gsd-build/get-shit-done](https://github.com/gsd-build/get-shit-done) |
+| npm package (upstream) | [npmjs.com/package/get-shit-done-cc](https://www.npmjs.com/package/get-shit-done-cc) |
+| Discord community | [discord.gg/5JJgD5svVS](https://discord.gg/5JJgD5svVS) |
+| Original author | [@glittercowboy](https://github.com/glittercowboy) |
 
-Clone the repository and run the installer locally:
-
-```bash
-git clone https://github.com/glittercowboy/get-shit-done.git
-cd get-shit-done
-node bin/install.js --claude --local
-```
-
-Installs to `./.claude/` for testing modifications before contributing.
-
-</details>
-
-### Recommended: Skip Permissions Mode
-
-GSD is designed for frictionless automation. Run Claude Code with:
-
-```bash
-claude --dangerously-skip-permissions
-```
-
-> [!TIP]
-> This is how GSD is intended to be used — stopping to approve `date` and `git commit` 50 times defeats the purpose.
-
-<details>
-<summary><strong>Alternative: Granular Permissions</strong></summary>
-
-If you prefer not to use that flag, add this to your project's `.claude/settings.json`:
-
-```json
-{
-  "permissions": {
-    "allow": [
-      "Bash(date:*)",
-      "Bash(echo:*)",
-      "Bash(cat:*)",
-      "Bash(ls:*)",
-      "Bash(mkdir:*)",
-      "Bash(wc:*)",
-      "Bash(head:*)",
-      "Bash(tail:*)",
-      "Bash(sort:*)",
-      "Bash(grep:*)",
-      "Bash(tr:*)",
-      "Bash(git add:*)",
-      "Bash(git commit:*)",
-      "Bash(git status:*)",
-      "Bash(git log:*)",
-      "Bash(git diff:*)",
-      "Bash(git tag:*)"
-    ]
-  }
-}
-```
-
-</details>
+All core GSD functionality  the planning system, workflow engine, templates, agents, and methodology  originates in the upstream project. This fork is a thin compatibility layer that maps those commands to VS Code Copilot Chat and keeps them up to date with upstream via automated sync.
 
 ---
 
 ## How It Works
 
-> **Already have code?** Run `/gsd:map-codebase` first. It spawns parallel agents to analyze your stack, architecture, conventions, and concerns. Then `/gsd:new-project` knows your codebase — questions focus on what you're adding, and planning automatically loads your patterns.
+> **Already have code?** Run `/gsd.map-codebase` first. It spawns parallel agents to analyze your stack, architecture, conventions, and concerns. Then `/gsd.new-project` knows your codebase  questions focus on what you're adding, and planning automatically loads your patterns.
 
 ### 1. Initialize Project
 
 ```
-/gsd:new-project
+/gsd.new-project
 ```
 
 One command, one flow. The system:
 
-1. **Questions** — Asks until it understands your idea completely (goals, constraints, tech preferences, edge cases)
-2. **Research** — Spawns parallel agents to investigate the domain (optional but recommended)
-3. **Requirements** — Extracts what's v1, v2, and out of scope
-4. **Roadmap** — Creates phases mapped to requirements
+1. **Questions**  Asks until it understands your idea completely (goals, constraints, tech preferences, edge cases)
+2. **Research**  Spawns parallel agents to investigate the domain (optional but recommended)
+3. **Requirements**  Extracts what's v1, v2, and out of scope
+4. **Roadmap**  Creates phases mapped to requirements
 
 You approve the roadmap. Now you're ready to build.
 
@@ -212,7 +129,7 @@ You approve the roadmap. Now you're ready to build.
 ### 2. Discuss Phase
 
 ```
-/gsd:discuss-phase 1
+/gsd.discuss-phase 1
 ```
 
 **This is where you shape the implementation.**
@@ -221,17 +138,15 @@ Your roadmap has a sentence or two per phase. That's not enough context to build
 
 The system analyzes the phase and identifies gray areas based on what's being built:
 
-- **Visual features** → Layout, density, interactions, empty states
-- **APIs/CLIs** → Response format, flags, error handling, verbosity
-- **Content systems** → Structure, tone, depth, flow
-- **Organization tasks** → Grouping criteria, naming, duplicates, exceptions
+- **Visual features**  Layout, density, interactions, empty states
+- **APIs/CLIs**  Response format, flags, error handling, verbosity
+- **Content systems**  Structure, tone, depth, flow
+- **Organization tasks**  Grouping criteria, naming, duplicates, exceptions
 
-For each area you select, it asks until you're satisfied. The output — `CONTEXT.md` — feeds directly into the next two steps:
+The output  `CONTEXT.md`  feeds directly into the next two steps:
 
-1. **Researcher reads it** — Knows what patterns to investigate ("user wants card layout" → research card component libraries)
-2. **Planner reads it** — Knows what decisions are locked ("infinite scroll decided" → plan includes scroll handling)
-
-The deeper you go here, the more the system builds what you actually want. Skip it and you get reasonable defaults. Use it and you get *your* vision.
+1. **Researcher reads it**  Knows what patterns to investigate
+2. **Planner reads it**  Knows what decisions are locked
 
 **Creates:** `{phase_num}-CONTEXT.md`
 
@@ -240,16 +155,16 @@ The deeper you go here, the more the system builds what you actually want. Skip 
 ### 3. Plan Phase
 
 ```
-/gsd:plan-phase 1
+/gsd.plan-phase 1
 ```
 
 The system:
 
-1. **Researches** — Investigates how to implement this phase, guided by your CONTEXT.md decisions
-2. **Plans** — Creates 2-3 atomic task plans with XML structure
-3. **Verifies** — Checks plans against requirements, loops until they pass
+1. **Researches**  Investigates how to implement this phase, guided by your CONTEXT.md decisions
+2. **Plans**  Creates 2-3 atomic task plans with XML structure
+3. **Verifies**  Checks plans against requirements, loops until they pass
 
-Each plan is small enough to execute in a fresh context window. No degradation, no "I'll be more concise now."
+Each plan is small enough to execute in a fresh context window.
 
 **Creates:** `{phase_num}-RESEARCH.md`, `{phase_num}-{N}-PLAN.md`
 
@@ -258,49 +173,15 @@ Each plan is small enough to execute in a fresh context window. No degradation, 
 ### 4. Execute Phase
 
 ```
-/gsd:execute-phase 1
+/gsd.execute-phase 1
 ```
 
 The system:
 
-1. **Runs plans in waves** — Parallel where possible, sequential when dependent
-2. **Fresh context per plan** — 200k tokens purely for implementation, zero accumulated garbage
-3. **Commits per task** — Every task gets its own atomic commit
-4. **Verifies against goals** — Checks the codebase delivers what the phase promised
-
-Walk away, come back to completed work with clean git history.
-
-**How Wave Execution Works:**
-
-Plans are grouped into "waves" based on dependencies. Within each wave, plans run in parallel. Waves run sequentially.
-
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│  PHASE EXECUTION                                                     │
-├─────────────────────────────────────────────────────────────────────┤
-│                                                                      │
-│  WAVE 1 (parallel)          WAVE 2 (parallel)          WAVE 3       │
-│  ┌─────────┐ ┌─────────┐    ┌─────────┐ ┌─────────┐    ┌─────────┐ │
-│  │ Plan 01 │ │ Plan 02 │ →  │ Plan 03 │ │ Plan 04 │ →  │ Plan 05 │ │
-│  │         │ │         │    │         │ │         │    │         │ │
-│  │ User    │ │ Product │    │ Orders  │ │ Cart    │    │ Checkout│ │
-│  │ Model   │ │ Model   │    │ API     │ │ API     │    │ UI      │ │
-│  └─────────┘ └─────────┘    └─────────┘ └─────────┘    └─────────┘ │
-│       │           │              ↑           ↑              ↑       │
-│       └───────────┴──────────────┴───────────┘              │       │
-│              Dependencies: Plan 03 needs Plan 01            │       │
-│                          Plan 04 needs Plan 02              │       │
-│                          Plan 05 needs Plans 03 + 04        │       │
-│                                                                      │
-└─────────────────────────────────────────────────────────────────────┘
-```
-
-**Why waves matter:**
-- Independent plans → Same wave → Run in parallel
-- Dependent plans → Later wave → Wait for dependencies
-- File conflicts → Sequential plans or same plan
-
-This is why "vertical slices" (Plan 01: User feature end-to-end) parallelize better than "horizontal layers" (Plan 01: All models, Plan 02: All APIs).
+1. **Runs plans in waves**  Parallel where possible, sequential when dependent
+2. **Fresh context per plan**  Tokens purely for implementation
+3. **Commits per task**  Every task gets its own atomic commit
+4. **Verifies against goals**  Checks the codebase delivers what the phase promised
 
 **Creates:** `{phase_num}-{N}-SUMMARY.md`, `{phase_num}-VERIFICATION.md`
 
@@ -309,70 +190,53 @@ This is why "vertical slices" (Plan 01: User feature end-to-end) parallelize bet
 ### 5. Verify Work
 
 ```
-/gsd:verify-work 1
+/gsd.verify-work 1
 ```
 
 **This is where you confirm it actually works.**
 
-Automated verification checks that code exists and tests pass. But does the feature *work* the way you expected? This is your chance to use it.
-
 The system:
 
-1. **Extracts testable deliverables** — What you should be able to do now
-2. **Walks you through one at a time** — "Can you log in with email?" Yes/no, or describe what's wrong
-3. **Diagnoses failures automatically** — Spawns debug agents to find root causes
-4. **Creates verified fix plans** — Ready for immediate re-execution
-
-If everything passes, you move on. If something's broken, you don't manually debug — you just run `/gsd:execute-phase` again with the fix plans it created.
+1. **Extracts testable deliverables**  What you should be able to do now
+2. **Walks you through one at a time**  Yes/no, or describe what's wrong
+3. **Diagnoses failures automatically**  Spawns debug agents to find root causes
+4. **Creates verified fix plans**  Ready for immediate re-execution
 
 **Creates:** `{phase_num}-UAT.md`, fix plans if issues found
 
 ---
 
-### 6. Repeat → Complete → Next Milestone
+### 6. Repeat  Complete  Next Milestone
 
 ```
-/gsd:discuss-phase 2
-/gsd:plan-phase 2
-/gsd:execute-phase 2
-/gsd:verify-work 2
+/gsd.discuss-phase 2
+/gsd.plan-phase 2
+/gsd.execute-phase 2
+/gsd.verify-work 2
 ...
-/gsd:complete-milestone
-/gsd:new-milestone
+/gsd.complete-milestone
+/gsd.new-milestone
 ```
 
-Loop **discuss → plan → execute → verify** until milestone complete.
-
-Each phase gets your input (discuss), proper research (plan), clean execution (execute), and human verification (verify). Context stays fresh. Quality stays high.
-
-When all phases are done, `/gsd:complete-milestone` archives the milestone and tags the release.
-
-Then `/gsd:new-milestone` starts the next version — same flow as `new-project` but for your existing codebase. You describe what you want to build next, the system researches the domain, you scope requirements, and it creates a fresh roadmap. Each milestone is a clean cycle: define → build → ship.
+Loop **discuss  plan  execute  verify** until milestone complete.
 
 ---
 
 ### Quick Mode
 
 ```
-/gsd:quick
+/gsd.quick
 ```
 
 **For ad-hoc tasks that don't need full planning.**
 
 Quick mode gives you GSD guarantees (atomic commits, state tracking) with a faster path:
 
-- **Same agents** — Planner + executor, same quality
-- **Skips optional steps** — No research, no plan checker, no verifier
-- **Separate tracking** — Lives in `.planning/quick/`, not phases
+- **Same agents**  Planner + executor, same quality
+- **Skips optional steps**  No research, no plan checker, no verifier
+- **Separate tracking**  Lives in `.planning/quick/`, not phases
 
 Use for: bug fixes, small features, config changes, one-off tasks.
-
-```
-/gsd:quick
-> What do you want to do? "Add dark mode toggle to settings"
-```
-
-**Creates:** `.planning/quick/001-add-dark-mode-toggle/PLAN.md`, `SUMMARY.md`
 
 ---
 
@@ -380,9 +244,7 @@ Use for: bug fixes, small features, config changes, one-off tasks.
 
 ### Context Engineering
 
-Claude Code is incredibly powerful *if* you give it the context it needs. Most people don't.
-
-GSD handles it for you:
+GSD handles context for you:
 
 | File | What it does |
 |------|--------------|
@@ -390,16 +252,14 @@ GSD handles it for you:
 | `research/` | Ecosystem knowledge (stack, features, architecture, pitfalls) |
 | `REQUIREMENTS.md` | Scoped v1/v2 requirements with phase traceability |
 | `ROADMAP.md` | Where you're going, what's done |
-| `STATE.md` | Decisions, blockers, position — memory across sessions |
+| `STATE.md` | Decisions, blockers, position  memory across sessions |
 | `PLAN.md` | Atomic task with XML structure, verification steps |
 | `SUMMARY.md` | What happened, what changed, committed to history |
 | `todos/` | Captured ideas and tasks for later work |
 
-Size limits based on where Claude's quality degrades. Stay under, get consistent excellence.
-
 ### XML Prompt Formatting
 
-Every plan is structured XML optimized for Claude:
+Every plan is structured XML:
 
 ```xml
 <task type="auto">
@@ -415,47 +275,18 @@ Every plan is structured XML optimized for Claude:
 </task>
 ```
 
-Precise instructions. No guessing. Verification built in.
-
 ### Multi-Agent Orchestration
-
-Every stage uses the same pattern: a thin orchestrator spawns specialized agents, collects results, and routes to the next step.
 
 | Stage | Orchestrator does | Agents do |
 |-------|------------------|-----------|
 | Research | Coordinates, presents findings | 4 parallel researchers investigate stack, features, architecture, pitfalls |
 | Planning | Validates, manages iteration | Planner creates plans, checker verifies, loop until pass |
-| Execution | Groups into waves, tracks progress | Executors implement in parallel, each with fresh 200k context |
+| Execution | Groups into waves, tracks progress | Executors implement in parallel, each with fresh context |
 | Verification | Presents results, routes next | Verifier checks codebase against goals, debuggers diagnose failures |
-
-The orchestrator never does heavy lifting. It spawns agents, waits, integrates results.
-
-**The result:** You can run an entire phase — deep research, multiple plans created and verified, thousands of lines of code written across parallel executors, automated verification against goals — and your main context window stays at 30-40%. The work happens in fresh subagent contexts. Your session stays fast and responsive.
 
 ### Atomic Git Commits
 
-Each task gets its own commit immediately after completion:
-
-```bash
-abc123f docs(08-02): complete user registration plan
-def456g feat(08-02): add email confirmation flow
-hij789k feat(08-02): implement password hashing
-lmn012o feat(08-02): create registration endpoint
-```
-
-> [!NOTE]
-> **Benefits:** Git bisect finds exact failing task. Each task independently revertable. Clear history for Claude in future sessions. Better observability in AI-automated workflow.
-
-Every commit is surgical, traceable, and meaningful.
-
-### Modular by Design
-
-- Add phases to current milestone
-- Insert urgent work between phases
-- Complete milestones and start fresh
-- Adjust plans without rebuilding everything
-
-You're never locked in. The system adapts.
+Each task gets its own commit immediately after completion. Git bisect finds the exact failing task. Every commit is surgical, traceable, and meaningful.
 
 ---
 
@@ -465,77 +296,73 @@ You're never locked in. The system adapts.
 
 | Command | What it does |
 |---------|--------------|
-| `/gsd:new-project [--auto]` | Full initialization: questions → research → requirements → roadmap |
-| `/gsd:discuss-phase [N] [--auto]` | Capture implementation decisions before planning |
-| `/gsd:plan-phase [N] [--auto]` | Research + plan + verify for a phase |
-| `/gsd:execute-phase <N>` | Execute all plans in parallel waves, verify when complete |
-| `/gsd:verify-work [N]` | Manual user acceptance testing ¹ |
-| `/gsd:audit-milestone` | Verify milestone achieved its definition of done |
-| `/gsd:complete-milestone` | Archive milestone, tag release |
-| `/gsd:new-milestone [name]` | Start next version: questions → research → requirements → roadmap |
+| `/gsd.new-project` | Full initialization: questions  research  requirements  roadmap |
+| `/gsd.discuss-phase [N]` | Capture implementation decisions before planning |
+| `/gsd.plan-phase [N]` | Research + plan + verify for a phase |
+| `/gsd.execute-phase <N>` | Execute all plans in parallel waves, verify when complete |
+| `/gsd.verify-work [N]` | Manual user acceptance testing |
+| `/gsd.audit-milestone` | Verify milestone achieved its definition of done |
+| `/gsd.complete-milestone` | Archive milestone, tag release |
+| `/gsd.new-milestone [name]` | Start next version: questions  research  requirements  roadmap |
 
 ### Navigation
 
 | Command | What it does |
 |---------|--------------|
-| `/gsd:progress` | Where am I? What's next? |
-| `/gsd:help` | Show all commands and usage guide |
-| `/gsd:update` | Update GSD with changelog preview |
-| `/gsd:join-discord` | Join the GSD Discord community |
+| `/gsd.progress` | Where am I? What's next? |
+| `/gsd.help` | Show all commands and usage guide |
+| `/gsd.update` | Update GSD with changelog preview |
+| `/gsd.join-discord` | Join the GSD Discord community |
 
 ### Brownfield
 
 | Command | What it does |
 |---------|--------------|
-| `/gsd:map-codebase` | Analyze existing codebase before new-project |
+| `/gsd.map-codebase` | Analyze existing codebase before new-project |
 
 ### Phase Management
 
 | Command | What it does |
 |---------|--------------|
-| `/gsd:add-phase` | Append phase to roadmap |
-| `/gsd:insert-phase [N]` | Insert urgent work between phases |
-| `/gsd:remove-phase [N]` | Remove future phase, renumber |
-| `/gsd:list-phase-assumptions [N]` | See Claude's intended approach before planning |
-| `/gsd:plan-milestone-gaps` | Create phases to close gaps from audit |
+| `/gsd.add-phase` | Append phase to roadmap |
+| `/gsd.insert-phase [N]` | Insert urgent work between phases |
+| `/gsd.remove-phase [N]` | Remove future phase, renumber |
+| `/gsd.list-phase-assumptions [N]` | See intended approach before planning |
+| `/gsd.plan-milestone-gaps` | Create phases to close gaps from audit |
 
 ### Session
 
 | Command | What it does |
 |---------|--------------|
-| `/gsd:pause-work` | Create handoff when stopping mid-phase |
-| `/gsd:resume-work` | Restore from last session |
+| `/gsd.pause-work` | Create handoff when stopping mid-phase |
+| `/gsd.resume-work` | Restore from last session |
 
 ### Utilities
 
 | Command | What it does |
 |---------|--------------|
-| `/gsd:settings` | Configure model profile and workflow agents |
-| `/gsd:set-profile <profile>` | Switch model profile (quality/balanced/budget) |
-| `/gsd:add-todo [desc]` | Capture idea for later |
-| `/gsd:check-todos` | List pending todos |
-| `/gsd:debug [desc]` | Systematic debugging with persistent state |
-| `/gsd:quick [--full]` | Execute ad-hoc task with GSD guarantees (`--full` adds plan-checking and verification) |
-| `/gsd:health [--repair]` | Validate `.planning/` directory integrity, auto-repair with `--repair` |
-
-<sup>¹ Contributed by reddit user OracleGreyBeard</sup>
+| `/gsd.settings` | Configure model profile and workflow agents |
+| `/gsd.set-profile <profile>` | Switch model profile (quality/balanced/budget) |
+| `/gsd.add-todo [desc]` | Capture idea for later |
+| `/gsd.check-todos` | List pending todos |
+| `/gsd.debug [desc]` | Systematic debugging with persistent state |
+| `/gsd.quick` | Execute ad-hoc task with GSD guarantees |
+| `/gsd.health [--repair]` | Validate `.planning/` directory integrity |
 
 ---
 
 ## Configuration
 
-GSD stores project settings in `.planning/config.json`. Configure during `/gsd:new-project` or update later with `/gsd:settings`. For the full config schema, workflow toggles, git branching options, and per-agent model breakdown, see the [User Guide](docs/USER-GUIDE.md#configuration-reference).
+GSD stores project settings in `.planning/config.json`. Configure during `/gsd.new-project` or update later with `/gsd.settings`.
 
 ### Core Settings
 
 | Setting | Options | Default | What it controls |
 |---------|---------|---------|------------------|
 | `mode` | `yolo`, `interactive` | `interactive` | Auto-approve vs confirm at each step |
-| `depth` | `quick`, `standard`, `comprehensive` | `standard` | Planning thoroughness (phases × plans) |
+| `depth` | `quick`, `standard`, `comprehensive` | `standard` | Planning thoroughness |
 
 ### Model Profiles
-
-Control which Claude model each agent uses. Balance quality vs token spend.
 
 | Profile | Planning | Execution | Verification |
 |---------|----------|-----------|--------------|
@@ -545,149 +372,41 @@ Control which Claude model each agent uses. Balance quality vs token spend.
 
 Switch profiles:
 ```
-/gsd:set-profile budget
+/gsd.set-profile budget
 ```
 
-Or configure via `/gsd:settings`.
-
 ### Workflow Agents
-
-These spawn additional agents during planning/execution. They improve quality but add tokens and time.
 
 | Setting | Default | What it does |
 |---------|---------|--------------|
 | `workflow.research` | `true` | Researches domain before planning each phase |
 | `workflow.plan_check` | `true` | Verifies plans achieve phase goals before execution |
 | `workflow.verifier` | `true` | Confirms must-haves were delivered after execution |
-| `workflow.auto_advance` | `false` | Auto-chain discuss → plan → execute without stopping |
-
-Use `/gsd:settings` to toggle these, or override per-invocation:
-- `/gsd:plan-phase --skip-research`
-- `/gsd:plan-phase --skip-verify`
-
-### Execution
-
-| Setting | Default | What it controls |
-|---------|---------|------------------|
-| `parallelization.enabled` | `true` | Run independent plans simultaneously |
-| `planning.commit_docs` | `true` | Track `.planning/` in git |
-
-### Git Branching
-
-Control how GSD handles branches during execution.
-
-| Setting | Options | Default | What it does |
-|---------|---------|---------|--------------|
-| `git.branching_strategy` | `none`, `phase`, `milestone` | `none` | Branch creation strategy |
-| `git.phase_branch_template` | string | `gsd/phase-{phase}-{slug}` | Template for phase branches |
-| `git.milestone_branch_template` | string | `gsd/{milestone}-{slug}` | Template for milestone branches |
-
-**Strategies:**
-- **`none`** — Commits to current branch (default GSD behavior)
-- **`phase`** — Creates a branch per phase, merges at phase completion
-- **`milestone`** — Creates one branch for entire milestone, merges at completion
-
-At milestone completion, GSD offers squash merge (recommended) or merge with history.
-
----
-
-## Security
-
-### Protecting Sensitive Files
-
-GSD's codebase mapping and analysis commands read files to understand your project. **Protect files containing secrets** by adding them to Claude Code's deny list:
-
-1. Open Claude Code settings (`.claude/settings.json` or global)
-2. Add sensitive file patterns to the deny list:
-
-```json
-{
-  "permissions": {
-    "deny": [
-      "Read(.env)",
-      "Read(.env.*)",
-      "Read(**/secrets/*)",
-      "Read(**/*credential*)",
-      "Read(**/*.pem)",
-      "Read(**/*.key)"
-    ]
-  }
-}
-```
-
-This prevents Claude from reading these files entirely, regardless of what commands you run.
-
-> [!IMPORTANT]
-> GSD includes built-in protections against committing secrets, but defense-in-depth is best practice. Deny read access to sensitive files as a first line of defense.
+| `workflow.auto_advance` | `false` | Auto-chain discuss  plan  execute without stopping |
 
 ---
 
 ## Troubleshooting
 
 **Commands not found after install?**
-- Restart your runtime to reload commands/skills
-- Verify files exist in `~/.claude/commands/gsd/` (global) or `./.claude/commands/gsd/` (local)
-- For Codex, verify skills exist in `~/.codex/skills/gsd-*/SKILL.md` (global) or `./.codex/skills/gsd-*/SKILL.md` (local)
+- Reload VS Code window (`Ctrl+Shift+P`  "Developer: Reload Window")
+- Verify files exist in `.github/prompts/gsd.*.prompt.md`
 
-**Commands not working as expected?**
-- Run `/gsd:help` to verify installation
-- Re-run `npx get-shit-done-cc` to reinstall
+**Installer blocked by execution policy?**
+- Use the `irm ... | iex` one-liner  that form is never blocked by execution policy
+- Or run `Unblock-File gsd-copilot-install.ps1` before running the script
+- See [gsd-copilot-installer/README.md](gsd-copilot-installer/README.md) for full options
 
-**Updating to the latest version?**
-```bash
-npx get-shit-done-cc@latest
-```
-
-**Using Docker or containerized environments?**
-
-If file reads fail with tilde paths (`~/.claude/...`), set `CLAUDE_CONFIG_DIR` before installing:
-```bash
-CLAUDE_CONFIG_DIR=/home/youruser/.claude npx get-shit-done-cc --global
-```
-This ensures absolute paths are used instead of `~` which may not expand correctly in containers.
-
-### Uninstalling
-
-To remove GSD completely:
-
-```bash
-# Global installs
-npx get-shit-done-cc --claude --global --uninstall
-npx get-shit-done-cc --opencode --global --uninstall
-npx get-shit-done-cc --codex --global --uninstall
-
-# Local installs (current project)
-npx get-shit-done-cc --claude --local --uninstall
-npx get-shit-done-cc --opencode --local --uninstall
-npx get-shit-done-cc --codex --local --uninstall
-```
-
-This removes all GSD commands, agents, hooks, and settings while preserving your other configurations.
+**Want the latest version?**
+Run the installer again  it always pulls the latest release.
 
 ---
 
-## Community Ports
+## Sync Policy
 
-OpenCode, Gemini CLI, and Codex are now natively supported via `npx get-shit-done-cc`.
+This fork **only syncs changes down** from [`gsd-build/get-shit-done`](https://github.com/gsd-build/get-shit-done)  it never pushes back. The CI pipeline (`upstream-sync.yml`) detects upstream changes, merges them, regenerates the Copilot wrapper layer, and opens a pull request on **this fork**. There is no automated path that creates pull requests or pushes commits to `gsd-build/get-shit-done`.
 
-These community ports pioneered multi-runtime support:
-
-| Project | Platform | Description |
-|---------|----------|-------------|
-| [gsd-opencode](https://github.com/rokicool/gsd-opencode) | OpenCode | Original OpenCode adaptation |
-| gsd-gemini (archived) | Gemini CLI | Original Gemini adaptation by uberfuzzy |
-
----
-
-## Star History
-
-<a href="https://star-history.com/#glittercowboy/get-shit-done&Date">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=glittercowboy/get-shit-done&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=glittercowboy/get-shit-done&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=glittercowboy/get-shit-done&type=Date" />
- </picture>
-</a>
+**Contributing to upstream:** If you want to contribute a fix or feature back to the original GSD project, do so manually by opening a PR directly on [gsd-build/get-shit-done](https://github.com/gsd-build/get-shit-done).
 
 ---
 
@@ -695,10 +414,12 @@ These community ports pioneered multi-runtime support:
 
 MIT License. See [LICENSE](LICENSE) for details.
 
+Core GSD system licensed MIT by TÂCHES / glittercowboy. This compatibility layer is also MIT.
+
 ---
 
 <div align="center">
 
-**Claude Code is powerful. GSD makes it reliable.**
+**GSD makes spec-driven development with AI reliable. This fork brings it to VS Code GitHub Copilot.**
 
 </div>

--- a/agents/gsd-upstream-sync.md
+++ b/agents/gsd-upstream-sync.md
@@ -1,0 +1,148 @@
+# GSD Upstream Sync Agent
+
+## Role
+You maintain perfect sync between the upstream GSD repository and this Copilot fork. When upstream changes break the generator or verifier scripts, you diagnose the issue and fix the scripts (never the upstream content).
+
+## Context
+This fork maintains a thin Copilot compatibility layer over GSD:
+- **Upstream (immutable):** `commands/gsd/**`, `get-shit-done/workflows/**`, `agents/**`
+- **Wrapper (maintained):** `.github/prompts/**` (generated), `.github/agents/**` (custom), scripts
+
+The golden rule: **never rewrite upstream content**. Only fix the wrapper generation pipeline.
+
+## When Invoked
+The sync workflow detected that:
+1. ✅ Upstream changes merged successfully
+2. ❌ `node scripts/generate-prompts.mjs` OR `node scripts/verify-prompts.mjs` failed
+
+Your job: diagnose and fix the generator/verifier scripts.
+
+## Task
+
+### 1. Read and Understand Current Script State
+
+First, examine the current generator and verifier:
+- `scripts/generate-prompts.mjs` — converts upstream commands to prompts
+- `scripts/verify-prompts.mjs` — ensures all commands have prompts
+- Understand their logic completely before modifying
+
+### 2. Identify What Changed Upstream
+
+Analyze the diff from upstream to understand:
+- Which files changed in `commands/gsd/**`?
+- Did command naming change? Format change? New fields in metadata?
+- Are there new agents or different structure in `get-shit-done/workflows/**`?
+
+### 3. Diagnose the Failure
+
+Run the failing scripts in your analysis:
+- What's the exact error message?
+- Which commands are missing or malformed?
+- Is it a parsing issue? A naming convention issue? A path issue?
+- Is the problem in the generator logic, or in how it reads upstream data?
+
+### 4. Fix the Scripts (Not Upstream)
+
+**CRITICAL:** You fix the generator/verifier scripts only. Never touch upstream content.
+
+Common fixes:
+- **New metadata fields:** Update YAML parser to handle them
+- **Changed command naming:** Update `normalizeName()` function
+- **New directory structure:** Update file listing logic
+- **Path changes:** Update path normalization
+- **Schema changes:** Update frontmatter parsing
+
+For each fix:
+1. Understand why the upstream change requires this
+2. Keep the fix minimal — don't refactor unrelated code
+3. Add comments explaining the change
+
+### 5. Verify the Fix Works
+
+After fixing:
+```bash
+node scripts/generate-prompts.mjs
+node scripts/verify-prompts.mjs
+```
+
+Both must succeed. If not, loop back to Step 3 (diagnose more carefully).
+
+### 6. Validate Generated Output
+
+Spot-check the generated prompts:
+- Do they contain the upstream content (converted correctly)?
+- Are file paths correct (converted ~/.claude/ → ./.claude/)?
+- Are @ includes converted to "Read file at" bullets?
+- Are descriptions and argument hints populated?
+
+### 7. Commit and Return
+
+Commit your changes:
+```bash
+git add scripts/generate-prompts.mjs scripts/verify-prompts.mjs .github/prompts/
+git commit -m "fix(sync): update generator for upstream changes"
+```
+
+Return success message with:
+- What was broken
+- How you fixed it
+- Verification that scripts now pass
+
+## Output Format
+
+When complete, return:
+
+```
+## SYNC SUCCESS ✓
+
+### What Was Broken
+[Brief explanation of the failure]
+
+### How It Was Fixed
+[Script changes made, with reasoning]
+
+### Verification
+- ✓ Generator passes: node scripts/generate-prompts.mjs
+- ✓ Verifier passes: node scripts/verify-prompts.mjs
+- ✓ [N] prompt files regenerated
+- ✓ No upstream files modified
+- ✓ Ready for PR merge
+```
+
+## Anti-Patterns (Never Do These)
+
+❌ Rewrite upstream command files
+❌ Change command naming conventions without updating verifier
+❌ Skip testing generator output
+❌ Make generator/verifier "fixes" while leaving upstream broken
+❌ Add new dependencies to scripts
+❌ Change the prompt output format without reason
+❌ Assume a failing file is corrupt — it's probably a generator bug
+
+## Example: What a Typical Fix Looks Like
+
+**Upstream changed:** Commands now have `---` separators in metadata
+
+**Generator broke:** YAML parser expected single-line metadata
+
+**Fix:** 
+```javascript
+// OLD: parsed first line only
+// NEW: collect all lines until --- separator
+function parseFrontmatter(md) {
+  if (!md.startsWith('---')) return { data: {}, body: md };
+  const end = md.indexOf('\n---', 3);  // ← Added support for multiline FM
+  // ... rest unchanged
+}
+```
+
+**Verification:** Ran generator, checked output format, verified verifier passes
+
+## Success Criteria
+
+- [ ] Generator script passes: `node scripts/generate-prompts.mjs`
+- [ ] Verifier script passes: `node scripts/verify-prompts.mjs`
+- [ ] No upstream files were modified
+- [ ] All generated prompts are valid
+- [ ] Changes committed and ready for PR
+

--- a/gsd-copilot-installer/README.md
+++ b/gsd-copilot-installer/README.md
@@ -1,0 +1,126 @@
+# GSD Copilot Installer
+
+Install GSD Copilot files into your VS Code workspace with a single PowerShell command — no Node.js required.
+
+---
+
+## Prerequisites
+
+- **PowerShell 5.1+** — built into Windows 10 and Windows 11 (no install needed)
+- Internet access to download from GitHub Releases
+- No Node.js, npm, or any other runtime required
+
+---
+
+## Quick Start
+
+### One-liner (recommended)
+
+Open a PowerShell terminal in your project root and run:
+
+```powershell
+irm "https://raw.githubusercontent.com/maitaitime/get-shit-done-github-copilot/main/gsd-copilot-installer/gsd-copilot-install.ps1" | iex
+```
+
+This pipes the script directly into PowerShell without saving it to disk, so execution policy is never an issue.
+
+To pass arguments (e.g. a specific tag):
+
+```powershell
+& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/maitaitime/get-shit-done-github-copilot/main/gsd-copilot-installer/gsd-copilot-install.ps1"))) -Tag v1.0.0
+```
+
+### Download-then-run
+
+If you prefer to inspect the script first:
+
+```powershell
+# 1. Download the installer
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/maitaitime/get-shit-done-github-copilot/main/gsd-copilot-installer/gsd-copilot-install.ps1" -OutFile gsd-copilot-install.ps1
+
+# 2. Unblock it (removes the internet zone mark Windows adds to downloaded files)
+Unblock-File gsd-copilot-install.ps1
+
+# 3. Run it
+.\gsd-copilot-install.ps1
+
+# 4. Clean up
+Remove-Item gsd-copilot-install.ps1
+```
+
+> **Note:** Step 2 (`Unblock-File`) is required. Without it, Windows blocks the script because it was downloaded from the internet and is not digitally signed.
+
+### Installing from the release zip
+
+If you extracted the release zip and want to run `gsd-copilot-install.ps1` from the extracted `gsd-copilot-installer/` folder, you **must** target your project root explicitly — running the installer from its own directory is blocked with a clear error.
+
+```powershell
+# Run from anywhere — point -WorkspaceDir at your project root
+Unblock-File .\gsd-copilot-installer\gsd-copilot-install.ps1
+.\gsd-copilot-installer\gsd-copilot-install.ps1 -WorkspaceDir "C:\path\to\your-project"
+```
+
+Or `cd` to your project root first, then unblock and run:
+
+```powershell
+cd "C:\path\to\your-project"
+Unblock-File .\path\to\gsd-copilot-installer\gsd-copilot-install.ps1
+.\path\to\gsd-copilot-installer\gsd-copilot-install.ps1
+```
+
+That's it. GSD Copilot is now set up in your workspace.
+
+---
+
+## What Gets Installed
+
+The installer writes into two top-level directories:
+
+**`.github/` (Copilot layer)**
+- `.github/prompts/` — VS Code slash command prompts (e.g. `/gsd.new-project`)
+- `.github/instructions/` — Reusable instruction files for Copilot context
+
+**`.claude/` (GSD runtime)**
+- `.claude/commands/gsd/` — Upstream GSD command definitions
+- `.claude/get-shit-done/` — GSD runtime: workflows, references, templates, bin
+- `.claude/agents/` — GSD agent definitions
+- `.claude/hooks/` — GSD hook scripts
+- `.claude/package.json` — CommonJS mode marker required by the GSD runtime
+
+Non-GSD files in `.github/` (your workflows, issue templates, etc.) are never touched.
+All files under `.claude/` in the workspace are GSD-owned and will be overwritten on upgrade.
+
+---
+
+## Options
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `-Tag <version>` | Install a specific release tag instead of latest | `.\gsd-copilot-install.ps1 -Tag v1.2.0` |
+| `-DryRun` | Preview what would be installed without writing any files | `.\gsd-copilot-install.ps1 -DryRun` |
+| `-Force` | Skip overwrite warnings; also overrides the downgrade block | `.\gsd-copilot-install.ps1 -Force` |
+| `-Verbose` | Show file-by-file output as the install runs | `.\gsd-copilot-install.ps1 -Verbose` |
+| `-WorkspaceDir <path>` | Target a directory other than the current one | `.\gsd-copilot-install.ps1 -WorkspaceDir C:\myproject` |
+
+---
+
+## Upgrading
+
+Re-run the same install command. GSD-owned files are overwritten with a warning; non-GSD files are untouched.
+
+## Downgrades
+
+Blocked by default — the installer exits with an error if the installed version is newer than the target. Use `-Force` to override.
+
+---
+
+## Safety
+
+- **Never touches non-GSD files** — only files from the release zip are written; your workflows, templates, and other `.github/` content remain unchanged.
+- **No backup created** — the installer relies on your workspace being under git version control. Run `git status` first if you're unsure.
+
+---
+
+## Version Tracking
+
+After a successful install, `.github/.gsd-version` is written with the installed version string. This file is used for downgrade detection on subsequent runs.

--- a/gsd-copilot-installer/gsd-copilot-install.ps1
+++ b/gsd-copilot-installer/gsd-copilot-install.ps1
@@ -1,0 +1,277 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Install GSD Copilot files into a target workspace.
+
+.DESCRIPTION
+    Downloads the GSD Copilot release zip from GitHub Releases and installs
+    .github/prompts/, .github/instructions/,
+    .claude/commands/gsd/, .claude/get-shit-done/, .claude/agents/,
+    .claude/hooks/, and .claude/package.json
+    into the target workspace without touching non-GSD files.
+
+.PARAMETER WorkspaceDir
+    Path to the target workspace. Defaults to the current directory.
+
+.PARAMETER Tag
+    Release tag to install (e.g. v1.2.0). Defaults to "latest".
+
+.PARAMETER DryRun
+    If specified, prints what would be written without actually writing files.
+
+.PARAMETER Force
+    If specified, skips conflict warnings and overrides the downgrade block.
+#>
+[CmdletBinding()]
+param(
+    [string]$WorkspaceDir = (Get-Location).Path,
+    [string]$Tag = "latest",
+    [switch]$DryRun,
+    [switch]$Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# Guard: warn if the script is being run from its own directory
+# (common mistake when extracting the zip and running from inside gsd-copilot-installer/)
+if ($WorkspaceDir -eq $PSScriptRoot) {
+    Write-Host ""
+    Write-Host "WARNING: You are running this installer from its own directory:"
+    Write-Host "  $PSScriptRoot"
+    Write-Host ""
+    Write-Host "GSD files will be installed into this folder, not your project."
+    Write-Host "Run the installer from your project root instead:"
+    Write-Host ""
+    Write-Host "  cd <your-project-root>"
+    Write-Host "  $PSCommandPath"
+    Write-Host ""
+    Write-Host "Or pass -WorkspaceDir explicitly:"
+    Write-Host ""
+    Write-Host "  .\gsd-copilot-installer\gsd-copilot-install.ps1 -WorkspaceDir '<your-project-root>'"
+    Write-Host ""
+    exit 1
+}
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+$REPO         = "maitaitime/get-shit-done-github-copilot"
+$ASSET_NAME   = "gsd-copilot-*.zip"
+$VERSION_FILE = ".github/.gsd-version"
+# ──────────────────────────────────────────────────────────────────────────────
+
+# ── 1. Resolve release metadata ───────────────────────────────────────────────
+try {
+    $headers = @{ "User-Agent" = "gsd-installer" }
+    if ($Tag -eq "latest") {
+        $apiUrl = "https://api.github.com/repos/$REPO/releases/latest"
+    } else {
+        $apiUrl = "https://api.github.com/repos/$REPO/releases/tags/$Tag"
+    }
+    $release = Invoke-RestMethod -Uri $apiUrl -Headers $headers
+} catch {
+    Write-Error "Failed to fetch release metadata from GitHub: $($_.Exception.Message)"
+    exit 1
+}
+
+$releaseVersion = $release.tag_name.TrimStart('v')
+$asset = $release.assets | Where-Object { $_.name -like $ASSET_NAME } | Select-Object -First 1
+if (-not $asset) {
+    Write-Error "No zip asset found in release $($release.tag_name). Expected asset matching: $ASSET_NAME"
+    exit 1
+}
+
+# ── 2. Downgrade check ────────────────────────────────────────────────────────
+$versionFilePath = Join-Path $WorkspaceDir $VERSION_FILE
+$installedVersion = $null
+if (Test-Path $versionFilePath) {
+    $installedVersion = (Get-Content $versionFilePath -Raw).Trim().TrimStart('v')
+}
+
+if ($installedVersion) {
+    try {
+        $installedVer = [System.Version]$installedVersion
+        $targetVer    = [System.Version]$releaseVersion
+        if ($installedVer -gt $targetVer) {
+            if (-not $Force) {
+                Write-Error "Downgrade blocked: installed v$installedVersion → target v$releaseVersion. Use -Force to override."
+                exit 1
+            } else {
+                Write-Host "⚠ Warning: downgrading from v$installedVersion to v$releaseVersion (-Force specified)."
+            }
+        }
+    } catch {
+        # Non-semver version string — skip comparison
+    }
+}
+
+# ── 3. Print install header ───────────────────────────────────────────────────
+$modeLabel = if ($DryRun) { "DRY RUN" } else { "normal" }
+Write-Host ""
+Write-Host "GSD Copilot Installer"
+Write-Host ""
+Write-Host "  Installing:  $REPO @ $($release.tag_name)"
+Write-Host "  Target:      $WorkspaceDir"
+Write-Host "  Mode:        $modeLabel"
+Write-Host ""
+
+# ── 4. Download and extract ───────────────────────────────────────────────────
+$writtenCount  = 0
+$overwroteCount = 0
+$skippedCount  = 0
+
+if (-not $DryRun) {
+    $tmpZip = Join-Path $env:TEMP "gsd-copilot-$($release.tag_name).zip"
+    $tmpDir = Join-Path $env:TEMP "gsd-copilot-extract-$($release.tag_name)"
+
+    try {
+        Write-Verbose "Downloading $($asset.browser_download_url)..."
+        Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $tmpZip
+
+        Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+        Expand-Archive -Path $tmpZip -DestinationPath $tmpDir -Force
+    } catch {
+        Write-Error "Download/extract failed: $($_.Exception.Message)"
+        exit 1
+    }
+
+    $srcRoot = Join-Path $tmpDir ".github"
+    if (-not (Test-Path $srcRoot)) {
+        Write-Error "Extracted zip does not contain a .github/ directory. Unexpected asset structure."
+        exit 1
+    }
+
+    $claudeSrcRoot = Join-Path $tmpDir ".claude"
+    if (-not (Test-Path $claudeSrcRoot)) {
+        Write-Error "Extracted zip does not contain a .claude/ directory. Unexpected asset structure."
+        exit 1
+    }
+
+    # ── 5. Install files ──────────────────────────────────────────────────────
+    try {
+        $files = Get-ChildItem -Recurse -File -Path $srcRoot
+        foreach ($src in $files) {
+            $rel  = $src.FullName.Substring($srcRoot.Length).TrimStart('\', '/')
+            $dest = Join-Path (Join-Path $WorkspaceDir ".github") $rel
+            $exists = Test-Path $dest
+
+            if ($exists) {
+                if ($Force) {
+                    New-Item -ItemType Directory -Force -Path (Split-Path $dest) | Out-Null
+                    Copy-Item -Path $src.FullName -Destination $dest -Force
+                    Write-Verbose "  Overwritten (--force): .github/$rel"
+                } else {
+                    Write-Host "  `u{26A0} Overwriting: .github/$rel"
+                    New-Item -ItemType Directory -Force -Path (Split-Path $dest) | Out-Null
+                    Copy-Item -Path $src.FullName -Destination $dest -Force
+                }
+                $writtenCount++
+                $overwroteCount++
+            } else {
+                New-Item -ItemType Directory -Force -Path (Split-Path $dest) | Out-Null
+                Copy-Item -Path $src.FullName -Destination $dest -Force
+                Write-Verbose "  Written: .github/$rel"
+                $writtenCount++
+            }
+        }
+    } catch {
+        Write-Error "Install failed writing .github/$rel`: $_"
+        exit 1
+    }
+
+    # ── 5b. Install .claude/ files ───────────────────────────────────────────
+    try {
+        $claudeFiles = Get-ChildItem -Recurse -File -Path $claudeSrcRoot
+        foreach ($src in $claudeFiles) {
+            $rel  = $src.FullName.Substring($claudeSrcRoot.Length).TrimStart('\', '/')
+            $dest = Join-Path (Join-Path $WorkspaceDir ".claude") $rel
+            $exists = Test-Path $dest
+
+            if ($exists) {
+                if ($Force) {
+                    New-Item -ItemType Directory -Force -Path (Split-Path $dest) | Out-Null
+                    Copy-Item -Path $src.FullName -Destination $dest -Force
+                    Write-Verbose "  Overwritten (--force): .claude/$rel"
+                } else {
+                    Write-Host "  `u{26A0} Overwriting: .claude/$rel"
+                    New-Item -ItemType Directory -Force -Path (Split-Path $dest) | Out-Null
+                    Copy-Item -Path $src.FullName -Destination $dest -Force
+                }
+                $writtenCount++
+                $overwroteCount++
+            } else {
+                New-Item -ItemType Directory -Force -Path (Split-Path $dest) | Out-Null
+                Copy-Item -Path $src.FullName -Destination $dest -Force
+                Write-Verbose "  Written: .claude/$rel"
+                $writtenCount++
+            }
+        }
+    } catch {
+        Write-Error "Install failed writing .claude/$rel`: $_"
+        exit 1
+    }
+
+    # ── 6. Write version marker ───────────────────────────────────────────────
+    New-Item -ItemType Directory -Force -Path (Split-Path $versionFilePath) | Out-Null
+    Set-Content -Path $versionFilePath -Value $releaseVersion -Encoding UTF8
+
+} else {
+    # DryRun: fetch manifest without downloading the zip
+    try {
+        $headers = @{ "User-Agent" = "gsd-installer" }
+        $tmpZip = Join-Path $env:TEMP "gsd-copilot-$($release.tag_name)-dryrun.zip"
+        $tmpDir = Join-Path $env:TEMP "gsd-copilot-extract-$($release.tag_name)-dryrun"
+        Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $tmpZip
+        Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+        Expand-Archive -Path $tmpZip -DestinationPath $tmpDir -Force
+        $srcRoot = Join-Path $tmpDir ".github"
+        $files = Get-ChildItem -Recurse -File -Path $srcRoot
+        foreach ($src in $files) {
+            $rel  = $src.FullName.Substring($srcRoot.Length).TrimStart('\', '/')
+            $dest = Join-Path (Join-Path $WorkspaceDir ".github") $rel
+            $exists = Test-Path $dest
+            if ($exists) {
+                Write-Host "[DRY-RUN] would overwrite: .github/$rel"
+            } else {
+                Write-Host "[DRY-RUN] would write: .github/$rel"
+            }
+        }
+        $claudeSrcRootDry = Join-Path $tmpDir ".claude"
+        if (Test-Path $claudeSrcRootDry) {
+            $claudeFilesDry = Get-ChildItem -Recurse -File -Path $claudeSrcRootDry
+            foreach ($src in $claudeFilesDry) {
+                $rel  = $src.FullName.Substring($claudeSrcRootDry.Length).TrimStart('\', '/')
+                $dest = Join-Path (Join-Path $WorkspaceDir ".claude") $rel
+                $exists = Test-Path $dest
+                if ($exists) {
+                    Write-Host "[DRY-RUN] would overwrite: .claude/$rel"
+                } else {
+                    Write-Host "[DRY-RUN] would write: .claude/$rel"
+                }
+            }
+        }
+        Remove-Item -Force $tmpZip -ErrorAction SilentlyContinue
+        Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+    } catch {
+        Write-Error "Dry-run failed fetching release manifest: $($_.Exception.Message)"
+        exit 1
+    }
+}
+
+# ── 7. Print summary ──────────────────────────────────────────────────────────
+Write-Host "------------------------------------------"
+if ($DryRun) {
+    Write-Host "No files written (dry run)"
+} else {
+    Write-Host "Done: $writtenCount written ($overwroteCount overwritten), $skippedCount skipped"
+    Write-Host "Version: $VERSION_FILE -> $releaseVersion"
+}
+Write-Host "------------------------------------------"
+Write-Host ""
+
+# ── 8. Cleanup temp files ──────────────────────────────────────────────────────
+if (-not $DryRun) {
+    Remove-Item -Force $tmpZip -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+}
+
+exit 0

--- a/scripts/generate-prompts.mjs
+++ b/scripts/generate-prompts.mjs
@@ -1,0 +1,592 @@
+// scripts/generate-prompts.mjs
+// Generates .github/prompts/*.prompt.md from upstream commands/gsd/*.md
+// No external deps. Minimal YAML frontmatter parsing.
+// Adds: Preflight + Copilot Runtime Adapter shim (universal).
+// Fixes: ~/.claude and /.claude path rewrites to workspace-local ./.claude.
+//
+// Determinism:
+// - stable file ordering
+// - stable formatting
+// - overwrite outputs
+
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const ROOT = process.cwd();
+const COMMANDS_DIR = path.join(ROOT, "commands", "gsd");
+const OUT_DIR = path.join(ROOT, ".github", "prompts");
+
+function readFile(p) {
+  return fs.readFileSync(p, "utf8");
+}
+
+function writeFile(p, content) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content, "utf8");
+}
+
+function listMarkdownFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".md") && !f.endsWith(".bak"))
+    .sort((a, b) => a.localeCompare(b))
+    .map((f) => path.join(dir, f));
+}
+
+// extremely small frontmatter parser: expects leading --- block
+function parseFrontmatter(md) {
+  if (!md.startsWith("---")) return { data: {}, body: md };
+
+  // Find closing delimiter on its own line
+  const match = md.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+  if (!match) return { data: {}, body: md };
+
+  const fm = match[1].trim();
+  const body = match[2].trimStart();
+
+  const data = {};
+  for (const line of fm.split(/\r?\n/)) {
+    const m = line.match(/^([A-Za-z0-9_-]+)\s*:\s*(.*)\s*$/);
+    if (!m) continue;
+    let [, k, v] = m;
+    v = v.trim();
+
+    // strip surrounding quotes if present
+    if (
+      (v.startsWith('"') && v.endsWith('"')) ||
+      (v.startsWith("'") && v.endsWith("'"))
+    ) {
+      v = v.slice(1, -1);
+    }
+
+    data[k] = v;
+  }
+
+  return { data, body };
+}
+
+/**
+ * Extract the `allowed-tools` array from a markdown file's YAML frontmatter.
+ *
+ * @param {string} content  Raw file content
+ * @param {string} [filePath]  For warning messages only
+ * @returns {string[] | null}
+ *   - string[]  when field is present and non-empty (lowercased tool names)
+ *   - []        when field is present but explicitly empty
+ *   - null      when field is absent
+ *
+ * Zero external dependencies. Hand-rolled state machine.
+ * Handles:
+ *   - Multi-line block sequence:  allowed-tools:\n  - Read\n  - Write
+ *   - Inline comma-separated scalar:  allowed-tools: Read, Write, Edit
+ *   - Field absent → null
+ *   - Wildcard entries (mcp__context7__*) preserved as-is (lowercased)
+ */
+export function parseFrontmatterTools(content, filePath = "<unknown>") {
+  // Normalize line endings once
+  const normalized = content.replace(/\r\n/g, "\n");
+
+  // Extract frontmatter block.
+  // Handles trailing spaces on delimiters and closing --- at EOF (no trailing newline).
+  const fmMatch = normalized.match(/^---[ \t]*\n([\s\S]*?)\n---[ \t]*(?:\n|$)/);
+  if (!fmMatch) return null;
+
+  const fmText = fmMatch[1];
+  const lines = fmText.split("\n");
+
+  const KEY_LINE = /^allowed-tools\s*:\s*(.*)$/;
+  const LIST_ITEM = /^\s+-\s+(.+)\s*$/;
+  const NEW_KEY = /^[A-Za-z0-9_-]+\s*:/;
+
+  let state = "SCANNING"; // SCANNING | COLLECTING
+  const tools = [];
+  let fieldFound = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (state === "SCANNING") {
+      const m = line.match(KEY_LINE);
+      if (!m) continue;
+
+      fieldFound = true;
+      const inline = m[1].trim();
+
+      if (inline) {
+        // Inline value: "Read, Write, Edit" or "[Read, Write, Edit]"
+        const stripped = inline.replace(/^\[/, "").replace(/\]$/, "");
+        const items = stripped
+          .split(/\s*,\s*/)
+          .map((s) => s.trim().toLowerCase())
+          .filter(Boolean);
+        return items.length ? items : [];
+      }
+
+      // Empty inline value — switch to block-collection mode
+      state = "COLLECTING";
+      continue;
+    }
+
+    if (state === "COLLECTING") {
+      // Terminator: blank line or new top-level key
+      if (line.trim() === "" || NEW_KEY.test(line)) break;
+
+      const itemMatch = line.match(LIST_ITEM);
+      if (itemMatch) {
+        const val = itemMatch[1].trim().toLowerCase();
+        if (val) tools.push(val);
+      } else {
+        // Unexpected line inside list block — warn and skip (do not crash)
+        // Include line number (i+1) per error-message format decision
+        console.warn(
+          `[parseFrontmatterTools] ${filePath}: line ${i + 1}: unexpected line in allowed-tools block: ${JSON.stringify(line)}`
+        );
+      }
+    }
+  }
+
+  if (!fieldFound) return null;
+  return tools; // [] if block was present but had no valid list items
+}
+
+export function loadToolMap() {
+  const p = path.join(ROOT, 'scripts', 'tools.json');
+  if (!fs.existsSync(p)) {
+    console.warn('[loadToolMap] scripts/tools.json not found — using empty map');
+    return {};
+  }
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch (e) {
+    console.error(`[loadToolMap] Failed to parse scripts/tools.json: ${e.message}`);
+    process.exitCode = 1;
+    return {};
+  }
+}
+
+function mapTools(upstreamTools, filePath, toolMap, pendingStubs) {
+  if (!upstreamTools || upstreamTools.length === 0) {
+    return { tools: [], omitted: [] };
+  }
+  const result = new Set();
+  const omitted = [];
+  const cmdBase = path.basename(filePath);
+
+  for (const tool of upstreamTools) {
+    if (tool.startsWith('mcp__')) {
+      result.add(tool);
+      continue;
+    }
+    // Bridge: parseFrontmatterTools() outputs lowercase; tools.json keys are Title-Case
+    const originalKey = Object.keys(toolMap).find(k => k.toLowerCase() === tool);
+    if (!originalKey) {
+      omitted.push(tool);
+      if (!(tool in pendingStubs)) pendingStubs[tool] = 'UNMAPPED';
+      console.warn(`WARN: unknown tool "${tool}" in ${cmdBase} — omitted`);
+      continue;
+    }
+    const mapped = toolMap[originalKey];
+    if (mapped === 'UNMAPPED') {
+      omitted.push(tool);
+      console.warn(`WARN: unknown tool "${tool}" in ${cmdBase} — omitted (UNMAPPED in tools.json)`);
+      continue;
+    }
+    result.add(mapped);
+  }
+  return { tools: [...result].sort(), omitted };
+}
+
+function normalizeName(name) {
+  // upstream uses gsd:new-project; VS Code prompt uses gsd.new-project
+  return String(name).replace(/^gsd:/, "gsd.").replace(/:/g, ".");
+}
+
+function convertIncludes(text) {
+  // Convert Claude-style @ includes into Copilot-friendly "Read file at:" bullets
+  // Be conservative: only lines where first non-whitespace is '@'
+  return text.replace(/^\s*@(?:include\s+)?(.+?)\s*$/gm, (m, p1) => {
+    return `- Read file at: ${p1.trim()}`;
+  });
+}
+
+function normalizeRuntimePathsForLocalInstall(text) {
+  // Convert global/home runtime paths to workspace-local paths.
+  // Handles:
+  // - ~/.claude/... -> ./.claude/...
+  // - /.claude/...  -> ./.claude/...   (important: appears in some upstream renderings)
+  // Also supports opencode/gemini if present.
+  return text
+    .replace(/~\/\.(claude|opencode|gemini)\//g, "./.$1/")
+    .replace(/(?<!\.)\/\.(claude|opencode|gemini)\//g, "./.$1/");
+}
+
+function adapterBlock() {
+  // Universal shim: map upstream AskUserQuestion to VS Code's askQuestions tool.
+  return `## Copilot Runtime Adapter (important)
+
+Upstream GSD command sources may reference an \`AskUserQuestion\` tool (Claude/OpenCode runtime concept).
+
+In VS Code Copilot, **do not attempt to call a tool named \`AskUserQuestion\`**.
+Instead, whenever the upstream instructions say "Use AskUserQuestion", use **#tool:vscode/askQuestions** with:
+
+- Combine the **Header** and **Question** into a single clear question string.
+- If the upstream instruction specifies **Options**, present them as numbered choices.
+- If no options are specified, ask as a freeform question.
+
+**Rules:**
+1. If the options include "Other", "Something else", or "Let me explain", and the user selects it, follow up with a freeform question via #tool:vscode/askQuestions.
+2. Follow the upstream branching and loop rules exactly as written (e.g., "if X selected, do Y; otherwise continue").
+3. If the upstream flow says to **exit/stop** and run another command, tell the user to run that slash command next, then stop.
+4. Use #tool:vscode/askQuestions freely — do not guess or assume user intent.
+
+---
+`;
+}
+
+function generatedBanner(sourceRel) {
+  return `<!-- GENERATED FILE — DO NOT EDIT.
+Source: ${sourceRel}
+Regenerate: node scripts/generate-prompts.mjs
+-->`;
+}
+
+function escapeYamlString(s) {
+  // safest deterministic quoting for YAML one-liners
+  return String(s ?? "").replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * Join non-empty string blocks with exactly one blank line between them.
+ * Filters out empty/whitespace-only blocks. No leading or trailing blank lines.
+ */
+function joinBlocks(...blocks) {
+  return blocks
+    .map(b => (typeof b === 'string' ? b.trimEnd() : ''))
+    .filter(b => b.length > 0)
+    .join('\n\n');
+}
+
+// ─── Pipeline Steps ──────────────────────────────────────────────────────────
+
+function stepParseFrontmatter(ctx) {
+  const { data, body } = parseFrontmatter(ctx.source);
+  ctx.fm = data;
+  ctx.body = body;
+  return ctx;
+}
+
+function stepNormalizeEol(ctx) {
+  if (ctx.source.includes('\r\n')) {
+    ctx._sourceEol = 'CRLF';
+    ctx.body = ctx.body.replace(/\r\n/g, '\n');
+  } else {
+    ctx._sourceEol = 'LF';
+  }
+  return ctx;
+}
+
+function stepParseTools(ctx) {
+  // Capture original-cased tool list BEFORE parseFrontmatterTools lowercases them.
+  const fmMatch = ctx.source.replace(/\r\n/g, '\n').match(/^---[ \t]*\n([\s\S]*?)\n---[ \t]*(?:\n|$)/);
+  let originals = null;
+  if (fmMatch) {
+    const fmText = fmMatch[1];
+    const KEY_LINE = /^allowed-tools\s*:\s*(.*)$/;
+    const LIST_ITEM = /^\s+-\s+(.+)\s*$/;
+    const NEW_KEY = /^[A-Za-z0-9_-]+\s*:/;
+    let state = 'SCANNING';
+    const items = [];
+    let found = false;
+    for (const line of fmText.split('\n')) {
+      if (state === 'SCANNING') {
+        const m = line.match(KEY_LINE);
+        if (!m) continue;
+        found = true;
+        const inline = m[1].trim();
+        if (inline) {
+          const stripped = inline.replace(/^\[/, '').replace(/\]$/, '');
+          originals = stripped.split(/\s*,\s*/).map(s => s.trim()).filter(Boolean);
+          break;
+        }
+        state = 'COLLECTING';
+        continue;
+      }
+      if (state === 'COLLECTING') {
+        if (line.trim() === '' || NEW_KEY.test(line)) break;
+        const itemMatch = line.match(LIST_ITEM);
+        if (itemMatch) items.push(itemMatch[1].trim());
+      }
+    }
+    if (state === 'COLLECTING') originals = items;
+    if (!found) originals = null;
+  }
+  ctx.upstreamToolsOriginal = originals; // original casing, may be null
+  ctx.upstreamTools = parseFrontmatterTools(ctx.source, ctx.cmdFile); // lowercased or null
+  return ctx;
+}
+
+function stepMapTools(ctx) {
+  const { tools, omitted } = mapTools(ctx.upstreamTools, ctx.cmdFile, ctx.toolMap, ctx.pendingStubs);
+  ctx.tools = tools;
+  ctx.omitted = omitted;
+  ctx.totalOmitted = (ctx.totalOmitted || 0) + omitted.length;
+  for (const t of omitted) ctx.allOmittedNames.add(t);
+  return ctx;
+}
+
+function stepConvertIncludes(ctx) {
+  ctx.body = convertIncludes(ctx.body);
+  return ctx;
+}
+
+function stepNormalizeRuntimePaths(ctx) {
+  ctx.body = normalizeRuntimePathsForLocalInstall(ctx.body);
+  return ctx;
+}
+
+/**
+ * Rewrite relative path references in body to workspace-relative paths.
+ *
+ * Handles:
+ * 1. Relative paths like ../foo/bar.md — resolved from source file's directory
+ * 2. @-prefixed file paths like @.planning/STATE.md — only when file exists
+ *
+ * Does NOT rewrite:
+ * - URLs (guarded by (?<![:/]) lookbehind)
+ * - @username tokens (require a / in the path portion to qualify)
+ * - Paths that cannot resolve to within ROOT (warns, leaves unchanged)
+ */
+function stepRewritePaths(ctx) {
+  const sourceDir = path.dirname(ctx.cmdFile);
+
+  // 1. Rewrite ../relative paths
+  ctx.body = ctx.body.replace(
+    /(?<![:/])(\.\.\/[^\s"')>\]]+)/g,
+    (match, relPath) => {
+      try {
+        const abs = path.resolve(sourceDir, relPath);
+        // Only rewrite if the file actually exists at the resolved location.
+        // Without this guard, ../foo from commands/gsd/ rewrites to commands/foo
+        // even when the real file lives at the workspace root (e.g. .claude/...).
+        if (!fs.existsSync(abs)) return match;
+        const rel = path.relative(ROOT, abs).replace(/\\/g, '/');
+        if (rel.startsWith('..')) {
+          console.warn(`WARN: [stepRewritePaths] ${path.basename(ctx.cmdFile)}: path resolves outside workspace root: ${relPath}`);
+          return match;
+        }
+        return rel;
+      } catch (e) {
+        console.warn(`WARN: [stepRewritePaths] ${path.basename(ctx.cmdFile)}: could not resolve path ${relPath}: ${e.message}`);
+        return match;
+      }
+    }
+  );
+
+  // 2. Rewrite @-prefixed file references (only if they contain a / and the file exists)
+  ctx.body = ctx.body.replace(
+    /(?<![A-Za-z0-9_-])@([\w./][^\s"')>\]]*\/[^\s"')>\]]*)/g,
+    (match, refPath) => {
+      try {
+        const absFromRoot = path.resolve(ROOT, refPath);
+        const absFromSource = path.resolve(sourceDir, refPath);
+        let resolved = null;
+        if (fs.existsSync(absFromRoot)) {
+          resolved = path.relative(ROOT, absFromRoot).replace(/\\/g, '/');
+        } else if (fs.existsSync(absFromSource)) {
+          resolved = path.relative(ROOT, absFromSource).replace(/\\/g, '/');
+        }
+        if (resolved === null) return match;
+        return '@' + resolved;
+      } catch (e) {
+        return match;
+      }
+    }
+  );
+
+  return ctx;
+}
+
+function stepAssemble(ctx) {
+  const upstreamName = ctx.fm.name || '';
+  const cmdName = upstreamName
+    ? normalizeName(upstreamName)
+    : 'gsd.' + path.basename(ctx.cmdFile, '.md');
+
+  const description = ctx.fm.description || `GSD command ${cmdName}`;
+  const argumentHint = ctx.fm['argument-hint'] || '';
+
+  const needsAskTool = ctx.tools.includes('vscode/askQuestions');
+
+  const sourceRel = path.posix.join('commands', 'gsd', path.basename(ctx.cmdFile));
+
+  // upstream-tools comment: use original casing
+  const toolsAnnotation = ctx.upstreamToolsOriginal === null
+    ? '<!-- upstream-tools: null (field absent in upstream command) -->'
+    : `<!-- upstream-tools: ${JSON.stringify(ctx.upstreamToolsOriginal)} -->`;
+
+  const omittedComment = ctx.omitted.length > 0
+    ? `<!-- omitted-tools: ${JSON.stringify(ctx.omitted)} — no Copilot equivalent found -->`
+    : '';
+
+  // tools frontmatter: omit field entirely when no upstream tools declared
+  const toolsYamlLine = ctx.upstreamTools === null
+    ? '' // omit
+    : `tools: [${ctx.tools.map(t => `'${t}'`).join(', ')}]`;
+
+  const frontmatterLines = [
+    `name: ${cmdName}`,
+    `description: "${escapeYamlString(description)}"`,
+    argumentHint ? `argument-hint: "${escapeYamlString(argumentHint)}"` : '',
+    toolsYamlLine,
+    `agent: agent`,
+  ].filter(l => l.length > 0);
+
+  const frontmatter = `---\n${frontmatterLines.join('\n')}\n---`;
+
+  const annotations = [toolsAnnotation, omittedComment].filter(Boolean).join('\n');
+
+  ctx.output = joinBlocks(
+    frontmatter,
+    annotations,
+    needsAskTool ? adapterBlock().trimEnd() : '',
+    ctx.body.trimEnd()
+  ) + '\n';
+
+  ctx.cmdName = cmdName;
+  return ctx;
+}
+
+function stepRestoreEol(ctx) {
+  if (ctx._sourceEol === 'CRLF') {
+    ctx.output = ctx.output.replace(/\n/g, '\r\n');
+  }
+  return ctx;
+}
+
+/**
+ * Validate that triple-backtick fences in ctx.output are balanced.
+ * Uses a line-scanning state machine (not regex) to avoid false positives.
+ *
+ * Sets ctx.skipWrite = true and emits an error to stderr if unbalanced.
+ */
+function stepValidateFences(ctx) {
+  const lines = ctx.output.split('\n');
+  let depth = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trimStart();
+    if (/^`{3,}/.test(trimmed)) {
+      depth = depth === 0 ? 1 : 0;
+    }
+  }
+
+  if (depth !== 0) {
+    console.error(
+      `ERROR: [stepValidateFences] ${path.basename(ctx.cmdFile)}: unbalanced fenced code block in output — file NOT written`
+    );
+    ctx.skipWrite = true;
+  }
+  return ctx;
+}
+
+export function runPipeline(ctx) {
+  const steps = [
+    stepParseFrontmatter,
+    stepNormalizeEol,
+    stepParseTools,
+    stepMapTools,
+    stepConvertIncludes,
+    stepNormalizeRuntimePaths,
+    stepRewritePaths,
+    stepAssemble,
+    stepRestoreEol,
+    stepValidateFences,
+  ];
+  for (const step of steps) step(ctx);
+  return ctx;
+}
+
+function main() {
+  const strict = process.argv.includes('--strict');
+  const toolMap = loadToolMap();
+  const toolsJsonPath = path.join(ROOT, 'scripts', 'tools.json');
+  const pendingStubs = {};
+  let totalOmitted = 0;
+  const allOmittedNames = new Set();
+  let fenceErrors = 0;
+  const expectedFiles = new Set();
+
+  const files = listMarkdownFiles(COMMANDS_DIR);
+  if (!files.length) {
+    console.error(`No command files found at ${COMMANDS_DIR}`);
+    process.exit(1);
+  }
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+
+  for (const f of files) {
+    const md = readFile(f);
+    const ctx = runPipeline({
+      source: md,
+      cmdFile: f,
+      toolMap,
+      pendingStubs,
+      allOmittedNames,
+      totalOmitted: 0,
+    });
+    totalOmitted += ctx.totalOmitted;
+    const prompt = ctx.output;
+
+    const base = path.basename(f, '.md'); // e.g., new-project
+    const outName = `gsd.${base}.prompt.md`;
+    const outPath = path.join(OUT_DIR, outName);
+
+    expectedFiles.add(outName);
+
+    if (!ctx.skipWrite) {
+      writeFile(outPath, prompt);
+    } else {
+      fenceErrors++;
+    }
+  }
+
+  // ─── Orphan Cleanup (GEN-09) ─────────────────────────────────────────────
+  // Remove .github/prompts/*.prompt.md files whose source command no longer exists.
+  if (fs.existsSync(OUT_DIR)) {
+    const existing = fs.readdirSync(OUT_DIR).filter(n => n.endsWith('.prompt.md'));
+    for (const name of existing) {
+      if (!expectedFiles.has(name)) {
+        const orphanPath = path.join(OUT_DIR, name);
+        fs.unlinkSync(orphanPath);
+        console.log(`Removed orphan: ${name}`);
+      }
+    }
+  }
+
+  // auto-stub write-back — one batch write AFTER all files processed
+  if (Object.keys(pendingStubs).length > 0) {
+    const updated = { ...toolMap, ...pendingStubs };
+    fs.writeFileSync(toolsJsonPath, JSON.stringify(updated, null, 2) + '\n', 'utf8');
+    console.warn(`\nWARN: auto-stubbed ${Object.keys(pendingStubs).length} unknown tools as UNMAPPED:`);
+    for (const t of Object.keys(pendingStubs)) console.warn(`  "${t}": "UNMAPPED"`);
+    console.warn('  Fill in Copilot equivalents before next run.\n');
+  }
+
+  if (fenceErrors > 0) {
+    console.error(`\nERROR: ${fenceErrors} file(s) skipped due to unbalanced fences.`);
+    process.exitCode = 1;
+  }
+
+  if (totalOmitted > 0) {
+    const hint = strict ? '' : ' (run with --strict to fail on unknown tools)';
+    console.log(`\n⚠ ${totalOmitted} unknown tool occurrences omitted: ${[...allOmittedNames].join(', ')}${hint}`);
+  }
+
+  if (strict && totalOmitted > 0) process.exitCode = 1;
+  console.log(`Generated ${files.length} prompt files into ${OUT_DIR}`);
+}
+
+const isMain = process.argv[1] != null && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) main();

--- a/scripts/guard-exemptions.txt
+++ b/scripts/guard-exemptions.txt
@@ -1,0 +1,15 @@
+# guard-exemptions.txt — Files this fork intentionally diverges from upstream.
+#
+# The repair agent guard (guard-upstream-files.sh) treats all files present in
+# upstream/main as "upstream-owned" and fails on any commit that modifies them.
+# Files listed here are EXCLUDED from that check because the fork deliberately
+# overrides them for its own identity, audience, or configuration.
+#
+# Rules:
+#   - One path per line (relative to repo root, no leading slash)
+#   - Lines starting with # are comments
+#   - Only add files here when the fork intentionally and permanently diverges
+#   - If a file is temporarily diverged (e.g. mid-PR sync), do NOT add it here
+#
+# Files intentionally owned by this fork:
+README.md

--- a/scripts/guard-upstream-files.sh
+++ b/scripts/guard-upstream-files.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# guard-upstream-files.sh — Prevents the repair agent from modifying upstream-owned files.
+# Usage: bash scripts/guard-upstream-files.sh pre-commit
+#        bash scripts/guard-upstream-files.sh post-commit
+set -euo pipefail
+
+MODE="${1:-post-commit}"
+
+# Dynamically detect upstream-owned files
+git ls-tree -r --name-only upstream/main | sort > /tmp/upstream-owned-files.txt
+
+# Load fork exemptions — files this fork intentionally diverges from upstream.
+# Defined in scripts/guard-exemptions.txt (one path per line, # = comment).
+EXEMPTIONS_FILE="$(dirname "$0")/guard-exemptions.txt"
+if [ -f "$EXEMPTIONS_FILE" ]; then
+  grep -v '^\s*#' "$EXEMPTIONS_FILE" | grep -v '^\s*$' | sort > /tmp/guard-exemptions.txt
+  # Remove exempted files from the upstream-owned list before violation checks
+  comm -23 /tmp/upstream-owned-files.txt /tmp/guard-exemptions.txt > /tmp/upstream-owned-filtered.txt
+else
+  cp /tmp/upstream-owned-files.txt /tmp/upstream-owned-filtered.txt
+fi
+
+if [ "$MODE" = "pre-commit" ]; then
+  # Check staged files
+  git diff --cached --name-only | sort > /tmp/staged-files.txt
+  VIOLATIONS=$(comm -12 /tmp/upstream-owned-filtered.txt /tmp/staged-files.txt || true)
+  if [ -n "$VIOLATIONS" ]; then
+    echo "::error::Filesystem guard (pre-commit): repair agent modified upstream-owned files:"
+    echo "$VIOLATIONS"
+    echo "$VIOLATIONS" | xargs git restore --staged
+    echo "::error::Staged changes reverted. Failing."
+    exit 1
+  fi
+  echo "Filesystem guard (pre-commit): no violations."
+elif [ "$MODE" = "post-commit" ]; then
+  # Determine the diff baseline.
+  # When called from the repair job, PRE_REPAIR_BASELINE contains the SHA recorded
+  # before any agent work ran. Using it means we only flag files the agent actually
+  # changed — not all files the fork legitimately diverges from upstream on.
+  # Fall back to upstream/main when no baseline is available (e.g. manual invocations).
+  if [ -n "${PRE_REPAIR_BASELINE:-}" ]; then
+    BASELINE="$PRE_REPAIR_BASELINE"
+    echo "Using pre-repair baseline: $BASELINE"
+  elif [ -f /tmp/pre-repair-sha ]; then
+    BASELINE=$(cat /tmp/pre-repair-sha)
+    echo "Using pre-repair baseline from file: $BASELINE"
+  else
+    BASELINE="upstream/main"
+    echo "No pre-repair baseline found; falling back to upstream/main."
+  fi
+  git diff --name-only "$BASELINE" HEAD | sort > /tmp/committed-files.txt
+  VIOLATIONS=$(comm -12 /tmp/upstream-owned-filtered.txt /tmp/committed-files.txt || true)
+  if [ -n "$VIOLATIONS" ]; then
+    echo "::error::Filesystem guard (post-commit): repair agent committed changes to upstream-owned files:"
+    echo "$VIOLATIONS"
+    # Restore each violated file to its upstream/main state.
+    # Every violation is guaranteed to exist in upstream/main because VIOLATIONS
+    # is the intersection of committed-files with the upstream-owned file list.
+    echo "$VIOLATIONS" | while IFS= read -r f; do
+      git checkout upstream/main -- "$f"
+    done
+    # Ensure git identity is set before amending (runner may not have it configured)
+    git config user.email "github-actions[bot]@users.noreply.github.com" 2>/dev/null || true
+    git config user.name "github-actions[bot]" 2>/dev/null || true
+    git commit --amend --no-edit || true
+    git push --force-with-lease origin HEAD
+    echo "::error::Upstream-owned files reverted and force-pushed. Failing."
+    exit 1
+  fi
+  echo "Filesystem guard (post-commit): no violations."
+else
+  echo "Unknown mode: $MODE. Use pre-commit or post-commit." >&2
+  exit 2
+fi

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -1,0 +1,14 @@
+{
+  "Read": "read",
+  "Write": "edit",
+  "Edit": "edit",
+  "Bash": "execute",
+  "Glob": "search",
+  "Grep": "search",
+  "Task": "agent",
+  "AskUserQuestion": "vscode/askQuestions",
+  "TodoWrite": "todo",
+  "WebSearch": "web",
+  "WebFetch": "web",
+  "slashcommand": "UNMAPPED"
+}

--- a/scripts/verify-prompts.mjs
+++ b/scripts/verify-prompts.mjs
@@ -1,0 +1,255 @@
+// scripts/verify-prompts.mjs
+// Multi-check verifier for the GSD → Copilot prompt compatibility layer.
+// Checks: VER-01 (coverage), VER-02 (tool accuracy), VER-03 (structural integrity),
+//         VER-04 (staleness — added in Plan 04-03), VER-05 (threshold warning)
+// Zero external dependencies.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { runPipeline, loadToolMap as loadToolMapGen } from './generate-prompts.mjs';
+
+const ROOT = process.cwd();
+const COMMANDS_DIR = path.join(ROOT, 'commands', 'gsd');
+const OUT_DIR = path.join(ROOT, '.github', 'prompts');
+const TOOLS_JSON_PATH = path.join(ROOT, 'scripts', 'tools.json');
+const MIN_COMMAND_COUNT = 20;
+const VERBOSE = process.argv.includes('--verbose');
+
+// ─── Color helpers (TTY-guarded) ─────────────────────────────────────────────
+const USE_COLOR = !!process.stdout.isTTY;
+const c = {
+  red:    s => USE_COLOR ? `\x1b[31m${s}\x1b[0m` : s,
+  yellow: s => USE_COLOR ? `\x1b[33m${s}\x1b[0m` : s,
+  green:  s => USE_COLOR ? `\x1b[32m${s}\x1b[0m` : s,
+  bold:   s => USE_COLOR ? `\x1b[1m${s}\x1b[0m`  : s,
+};
+
+// ─── Error/warning collectors ────────────────────────────────────────────────
+const errors = [];
+const warnings = [];
+
+function addError(checkType, file, message) {
+  errors.push({ checkType, file, message });
+}
+function addWarning(checkType, file, message) {
+  warnings.push({ checkType, file, message });
+}
+
+// ─── Grouped output ──────────────────────────────────────────────────────────
+function printGrouped(items, headerFn) {
+  const byType = {};
+  for (const item of items) {
+    (byType[item.checkType] ??= []).push(item);
+  }
+  for (const [checkType, group] of Object.entries(byType)) {
+    console.log(headerFn(checkType, group.length));
+    for (const { file, message } of group) {
+      console.log(`  - ${file ? file + ': ' : ''}${message}`);
+    }
+  }
+}
+
+// ─── File listing helpers ────────────────────────────────────────────────────
+function listUpstreamCommands() {
+  if (!fs.existsSync(COMMANDS_DIR)) return [];
+  return fs.readdirSync(COMMANDS_DIR)
+    .filter(f => f.endsWith('.md') && !f.endsWith('.bak'))
+    .sort();
+}
+
+function listPromptFiles() {
+  if (!fs.existsSync(OUT_DIR)) return new Set();
+  return new Set(fs.readdirSync(OUT_DIR).filter(f => f.endsWith('.prompt.md')));
+}
+
+function readPrompt(name) {
+  const p = path.join(OUT_DIR, name);
+  return fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : null;
+}
+
+// ─── SHA-256 helper ──────────────────────────────────────────────────────────
+function sha256(s) {
+  return crypto.createHash('sha256').update(s).digest('hex');
+}
+
+// ─── Tool map loader (mirrors generator — zero-dep, no import) ───────────────
+function loadToolMap() {
+  if (!fs.existsSync(TOOLS_JSON_PATH)) return {};
+  try { return JSON.parse(fs.readFileSync(TOOLS_JSON_PATH, 'utf8')); }
+  catch { return {}; }
+}
+
+// ─── Prompt parsing helpers ──────────────────────────────────────────────────
+function parseUpstreamToolsComment(promptContent) {
+  if (promptContent.includes('<!-- upstream-tools: null')) return null;
+  const m = promptContent.match(/<!-- upstream-tools: (\[.*?\]) -->/);
+  if (!m) return null;
+  try { return JSON.parse(m[1]); } catch { return null; }
+}
+
+function parseToolsFrontmatter(promptContent) {
+  const m = promptContent.match(/^tools:\s*\[([^\]]*)\]/m);
+  if (!m || !m[1].trim()) return null;
+  return m[1].split(',').map(s => s.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean);
+}
+
+function mapUpstreamTools(upstreamOriginals, toolMap) {
+  if (!upstreamOriginals || upstreamOriginals.length === 0) return [];
+  const result = new Set();
+  for (const tool of upstreamOriginals) {
+    // mcp__ prefixed tools pass through as-is (mirrors generator behavior)
+    if (tool.toLowerCase().startsWith('mcp__')) {
+      result.add(tool.toLowerCase());
+      continue;
+    }
+    const key = Object.keys(toolMap).find(k => k.toLowerCase() === tool.toLowerCase());
+    if (!key) continue;
+    const mapped = toolMap[key];
+    if (mapped === 'UNMAPPED') continue;
+    result.add(mapped);
+  }
+  return [...result].sort();
+}
+
+// ─── Check functions ─────────────────────────────────────────────────────────
+
+// VER-05: threshold warning
+function checkThreshold(cmdFiles) {
+  if (cmdFiles.length < MIN_COMMAND_COUNT) {
+    addWarning('VER-05', '', `only ${cmdFiles.length} upstream commands found (minimum: ${MIN_COMMAND_COUNT}) — possible silent upstream refactor`);
+  }
+}
+
+// VER-01: coverage
+function checkCoverage(cmdFiles, promptFiles) {
+  for (const cmd of cmdFiles) {
+    const base = cmd.replace(/\.md$/, '');
+    const expected = `gsd.${base}.prompt.md`;
+    if (!promptFiles.has(expected)) {
+      addError('VER-01', expected, 'missing — no generated prompt for this upstream command');
+    }
+  }
+}
+
+// VER-02: tool accuracy
+function checkToolAccuracy(promptName, promptContent, toolMap) {
+  const upstream = parseUpstreamToolsComment(promptContent);
+  if (upstream === null) return; // no upstream tools declared — skip
+
+  const expected = mapUpstreamTools(upstream, toolMap);
+  const actual = parseToolsFrontmatter(promptContent) ?? [];
+  const actualSorted = [...actual].sort();
+  const expectedSorted = [...expected].sort();
+
+  if (JSON.stringify(actualSorted) !== JSON.stringify(expectedSorted)) {
+    addError('VER-02', promptName,
+      `tools mismatch — expected [${expectedSorted.join(', ')}] but found [${actualSorted.join(', ')}]`);
+  }
+}
+
+// VER-03: structural integrity
+function checkStructuralIntegrity(promptName, promptContent, upstreamSource) {
+  // Only flag missing <execution_context> if the upstream source has one.
+  // Some upstream commands (e.g. debug.md, join-discord.md, reapply-patches.md,
+  // research-phase.md) have no <execution_context> block — their generated
+  // prompts correctly omit it, so flagging them would be a false positive.
+  if (upstreamSource.includes('<execution_context>') && !promptContent.includes('<execution_context>')) {
+    addError('VER-03', promptName, 'missing <execution_context> block');
+  }
+  // Adapter shim only required when vscode/askQuestions is in the tools list
+  const tools = parseToolsFrontmatter(promptContent);
+  if (tools !== null && tools.includes('vscode/askQuestions')) {
+    if (!promptContent.includes('#tool:vscode/askQuestions')) {
+      addError('VER-03', promptName, 'missing adapter shim (#tool:vscode/askQuestions) — required because vscode/askQuestions is in tools list');
+    }
+  }
+}
+
+// VER-04: staleness detection (warning only)
+function checkStaleness(cmdFiles, promptFiles) {
+  const genToolMap = loadToolMapGen();
+  const pendingStubs = {};
+
+  for (const cmd of cmdFiles) {
+    const base = cmd.replace(/\.md$/, '');
+    const promptName = `gsd.${base}.prompt.md`;
+    if (!promptFiles.has(promptName)) continue; // missing — already VER-01 error
+
+    const onDisk = readPrompt(promptName);
+    if (!onDisk) continue;
+
+    const cmdPath = path.join(COMMANDS_DIR, cmd);
+    const source = fs.readFileSync(cmdPath, 'utf8');
+
+    const ctx = runPipeline({
+      source,
+      cmdFile: cmdPath,
+      toolMap: genToolMap,
+      pendingStubs,
+      allOmittedNames: new Set(),
+      totalOmitted: 0,
+    });
+
+    if (ctx.skipWrite) continue; // generator would have skipped this file (fence error)
+
+    // LF-normalize both sides before comparing to avoid false positives on Windows
+    const expected = ctx.output.replace(/\r\n/g, '\n');
+    const actual   = onDisk.replace(/\r\n/g, '\n');
+
+    if (sha256(expected) !== sha256(actual)) {
+      addWarning('VER-04', promptName, 'stale — content differs from what generator would produce today; run: node scripts/generate-prompts.mjs');
+    }
+  }
+}
+
+// ─── main() ──────────────────────────────────────────────────────────────────
+async function main() {
+  const cmdFiles = listUpstreamCommands();
+  const promptFiles = listPromptFiles();
+
+  // VER-05: threshold (warning)
+  checkThreshold(cmdFiles);
+
+  // VER-01: coverage (hard error)
+  checkCoverage(cmdFiles, promptFiles);
+
+  // VER-02 and VER-03: per-prompt checks
+  const toolMap = loadToolMap();
+  for (const cmd of cmdFiles) {
+    const base = cmd.replace(/\.md$/, '');
+    const promptName = `gsd.${base}.prompt.md`;
+    if (!promptFiles.has(promptName)) continue; // already flagged by VER-01
+    const content = readPrompt(promptName);
+    if (!content) continue;
+    const upstreamSource = fs.readFileSync(path.join(COMMANDS_DIR, cmd), 'utf8');
+    checkToolAccuracy(promptName, content, toolMap);
+    checkStructuralIntegrity(promptName, content, upstreamSource);
+  }
+
+  // VER-04: staleness (warning only)
+  checkStaleness(cmdFiles, promptFiles);
+
+  // ─── Reporting ──────────────────────────────────────────────────────────
+  if (warnings.length > 0) {
+    console.log('');
+    printGrouped(warnings, (type, n) => c.yellow(`[${type}] ${n} warning(s):`));
+  }
+
+  if (errors.length > 0) {
+    console.log('');
+    printGrouped(errors, (type, n) => c.red(`[${type}] ${n} error(s):`));
+    const checkTypes = new Set(errors.map(e => e.checkType));
+    console.log('');
+    console.log(c.red(c.bold(`${errors.length} error(s) across ${checkTypes.size} check type(s)`)));
+    process.exit(1);
+  }
+
+  const detail = VERBOSE
+    ? cmdFiles.map(f => `  ✓ gsd.${f.replace(/\.md$/, '')}.prompt.md`).join('\n') + '\n'
+    : '';
+  if (detail) console.log(detail.trimEnd());
+  console.log(c.green(`✓ All checks passed (${cmdFiles.length} prompts verified)`));
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
- Introduced `generate-prompts.mjs` for generating prompts from upstream command markdown files, including YAML frontmatter parsing and tool mapping.
- Added `guard-exemptions.txt` to specify files intentionally diverging from upstream.
- Implemented `guard-upstream-files.sh` to prevent modifications to upstream-owned files during commits.
- Created `tools.json` for mapping upstream tools to Copilot equivalents.
- Developed `verify-prompts.mjs` to validate prompt files for coverage, tool accuracy, structural integrity, and staleness.
